### PR TITLE
Add configurable fetch_content backend: httpx / curl (TLS-impersonation) / auto 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,49 @@ uvx duckduckgo-mcp-server --transport streamable-http
 
 The default transport is `stdio`, which is used by Claude Desktop and Claude Code.
 
+### Fetch Backend (bypassing bot detection)
+
+Some sites block the default `httpx` client because of its distinctive TLS fingerprint, regardless of User-Agent — Cloudflare Bot Management and similar filters key on the JA3/TLS handshake, not on headers. An opt-in backend, `curl` (implemented via `curl_cffi`), impersonates a real Chrome browser's TLS handshake and passes through those checks.
+
+**Installation:**
+
+```bash
+# Default install (httpx only)
+uv pip install duckduckgo-mcp-server
+
+# With the optional browser backend
+uv pip install "duckduckgo-mcp-server[browser]"
+```
+
+**Backend options:**
+
+| Value  | Behavior                                                                                  | Needs `[browser]` |
+| ------ | ----------------------------------------------------------------------------------------- | ----------------- |
+| `httpx` | Lightweight async HTTP. Default. Works on most sites.                                     | no                |
+| `curl` | Uses `curl_cffi` with Chrome 131 TLS impersonation. Passes TLS-fingerprint-based filters. | yes               |
+| `auto` | Tries `httpx` first; on 403 or a Cloudflare challenge response, retries with `curl`.      | yes               |
+
+**Two ways to configure the backend:**
+
+1. **Server-wide default** via the `--fetch-backend` CLI flag (applies to every `fetch_content` call):
+
+   ```bash
+   # Default behavior — uses httpx
+   uvx duckduckgo-mcp-server
+
+   # Force curl for every fetch (requires the [browser] extra)
+   uvx --with "duckduckgo-mcp-server[browser]" duckduckgo-mcp-server --fetch-backend curl
+
+   # Try httpx first, fall back to curl on 403 / Cloudflare challenge
+   uvx --with "duckduckgo-mcp-server[browser]" duckduckgo-mcp-server --fetch-backend auto
+   ```
+
+2. **Per-call override** via the `backend` argument on the `fetch_content` tool (overrides the CLI default for that single call). The tool exposes `backend` in its input schema, so an MCP client can choose `"httpx"`, `"curl"`, or `"auto"` on a fetch-by-fetch basis.
+
+The `search` tool always uses `httpx` — DuckDuckGo's search endpoint doesn't require impersonation.
+
+The default stays `httpx` so users who don't need the impersonation don't pay for the extra dependency.
+
 ### Development
 
 For local development:
@@ -158,13 +201,21 @@ Formatted string containing search results with titles, URLs, and snippets.
 ### 2. Content Fetching Tool
 
 ```python
-async def fetch_content(url: str) -> str
+async def fetch_content(
+    url: str,
+    start_index: int = 0,
+    max_length: int = 8000,
+    backend: Optional[str] = None,
+) -> str
 ```
 
 Fetches and parses content from a webpage.
 
 **Parameters:**
 - `url`: The webpage URL to fetch content from
+- `start_index`: Character offset to start reading from (for pagination)
+- `max_length`: Maximum number of characters to return
+- `backend`: Optional per-call override of the default fetch backend (`"httpx"`, `"curl"`, or `"auto"`). When omitted, uses whatever was set via `--fetch-backend` at server startup.
 
 **Returns:**
 Cleaned and formatted text content from the webpage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,13 @@ classifiers = [
 Homepage = "https://github.com/nickclyde/duckduckgo-mcp-server"
 Issues = "https://github.com/nickclyde/duckduckgo-mcp-server/issues"
 
+# Optional extras. Install with e.g. `pip install duckduckgo-mcp-server[browser]`.
+[project.optional-dependencies]
+# Enables the `--fetch-backend curl` option (and `auto` fallback), which uses
+# curl_cffi to impersonate a real browser's TLS fingerprint so fetch_content
+# can pass through TLS-fingerprint-based bot filters. Not needed for basic use.
+browser = ["curl_cffi>=0.7.0"]
+
 [project.scripts]
 duckduckgo-mcp-server = "duckduckgo_mcp_server.server:main"
 

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -177,30 +177,135 @@ class DuckDuckGoSearcher:
             return []
 
 
+SUPPORTED_FETCH_BACKENDS = ("httpx", "curl", "auto")
+
+# Cloudflare / bot-filter challenge signals that appear in response bodies even
+# when the HTTP status is 200. If we see these on an httpx fetch under `auto`,
+# we retry with curl (Chrome TLS impersonation) which typically passes.
+_CLOUDFLARE_BODY_SIGNALS = (
+    "cf-mitigated",
+    "Just a moment...",
+    "Enable JavaScript and cookies to continue",
+    "Checking your browser before accessing",
+)
+
+
+def _is_cloudflare_challenge_body(html: str) -> bool:
+    if not html:
+        return False
+    sample = html[:4096]
+    return any(sig in sample for sig in _CLOUDFLARE_BODY_SIGNALS)
+
+
 class WebContentFetcher:
-    def __init__(self):
+    def __init__(self, backend: str = "httpx"):
+        """
+        Initialize the web content fetcher.
+
+        Args:
+            backend: HTTP client backend used for fetch_content. One of:
+              - "httpx" (default): lightweight async HTTP client. Works for most sites.
+              - "curl": uses curl_cffi with Chrome 131 TLS impersonation to bypass
+                TLS-fingerprint-based bot filters (Cloudflare Bot Management, Wikipedia,
+                etc.). Requires the optional [browser] extra:
+                `pip install 'duckduckgo-mcp-server[browser]'`.
+              - "auto": try httpx first; if the response looks like a 403 or a
+                Cloudflare challenge, transparently retry with curl.
+        """
+        if backend not in SUPPORTED_FETCH_BACKENDS:
+            raise ValueError(
+                f"Unknown fetch backend '{backend}'. Supported: {SUPPORTED_FETCH_BACKENDS}"
+            )
+        self.default_backend = backend
         self.rate_limiter = RateLimiter(requests_per_minute=20)
 
-    async def fetch_and_parse(self, url: str, ctx: Context, start_index: int = 0, max_length: int = 8000) -> str:
-        """Fetch and parse content from a webpage"""
+    async def _fetch_httpx(self, url: str) -> str:
+        """Fetch URL via httpx. Raises httpx.HTTPStatusError on non-2xx."""
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+                },
+                follow_redirects=True,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            return response.text
+
+    async def _fetch_curl(self, url: str) -> str:
+        """Fetch URL via curl_cffi with Chrome 131 TLS impersonation."""
+        try:
+            from curl_cffi.requests import AsyncSession
+        except ImportError as e:
+            raise RuntimeError(
+                "The 'curl' fetch backend requires curl_cffi, which is not installed. "
+                "Install the optional extra: pip install 'duckduckgo-mcp-server[browser]'"
+            ) from e
+        async with AsyncSession(impersonate="chrome131") as client:
+            response = await client.get(url, allow_redirects=True, timeout=30.0)
+            response.raise_for_status()
+            return response.text
+
+    async def _fetch_auto(self, url: str, ctx: Context) -> str:
+        """
+        Try httpx first. On signals that usually indicate TLS-fingerprint blocking
+        (403, or a Cloudflare challenge body at 200), fall back to curl.
+        """
+        try:
+            html = await self._fetch_httpx(url)
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code if e.response is not None else None
+            if status == 403:
+                await ctx.info(f"httpx got 403 for {url}; retrying with curl backend")
+                return await self._fetch_curl(url)
+            raise
+
+        if _is_cloudflare_challenge_body(html):
+            await ctx.info(f"httpx got Cloudflare challenge for {url}; retrying with curl backend")
+            return await self._fetch_curl(url)
+
+        return html
+
+    async def fetch_and_parse(
+        self,
+        url: str,
+        ctx: Context,
+        start_index: int = 0,
+        max_length: int = 8000,
+        backend: Optional[str] = None,
+    ) -> str:
+        """Fetch and parse content from a webpage.
+
+        Args:
+            url: Target URL.
+            ctx: MCP context for logging.
+            start_index: Pagination offset in characters.
+            max_length: Max characters to return.
+            backend: Optional per-call override of the default backend. One of
+                "httpx", "curl", "auto". When None, uses the server's default_backend.
+        """
+        effective_backend = backend if backend is not None else self.default_backend
+        if effective_backend not in SUPPORTED_FETCH_BACKENDS:
+            return (
+                f"Error: Unknown fetch backend '{effective_backend}'. "
+                f"Supported: {SUPPORTED_FETCH_BACKENDS}"
+            )
+
         try:
             await self.rate_limiter.acquire()
 
-            await ctx.info(f"Fetching content from: {url}")
+            await ctx.info(f"Fetching content from: {url} (backend={effective_backend})")
 
-            async with httpx.AsyncClient() as client:
-                response = await client.get(
-                    url,
-                    headers={
-                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
-                    },
-                    follow_redirects=True,
-                    timeout=30.0,
-                )
-                response.raise_for_status()
+            if effective_backend == "httpx":
+                html = await self._fetch_httpx(url)
+            elif effective_backend == "curl":
+                html = await self._fetch_curl(url)
+            else:  # auto
+                html = await self._fetch_auto(url, ctx)
 
             # Parse the HTML
-            soup = BeautifulSoup(response.text, "html.parser")
+            soup = BeautifulSoup(html, "html.parser")
 
             # Remove script and style elements
             for element in soup(["script", "style", "nav", "header", "footer"]):
@@ -241,7 +346,18 @@ class WebContentFetcher:
         except httpx.HTTPError as e:
             await ctx.error(f"HTTP error occurred while fetching {url}: {str(e)}")
             return f"Error: Could not access the webpage ({str(e)})"
+        except RuntimeError as e:
+            # Raised when curl backend is requested but curl_cffi isn't installed.
+            await ctx.error(str(e))
+            return f"Error: {str(e)}"
         except Exception as e:
+            # curl_cffi raises its own exception types; treat anything from the
+            # curl path as a generic fetch error so we don't leak a stack trace
+            # into the tool response.
+            err_type = type(e).__name__
+            if "curl_cffi" in f"{type(e).__module__}" or err_type.lower().startswith(("curl", "timeout")):
+                await ctx.error(f"curl fetch error for {url}: {err_type}: {str(e)}")
+                return f"Error: Could not access the webpage ({err_type}: {str(e)})"
             await ctx.error(f"Error fetching content from {url}: {str(e)}")
             return f"Error: An unexpected error occurred while fetching the webpage ({str(e)})"
 
@@ -287,19 +403,27 @@ async def search(query: str, ctx: Context, max_results: int = 10, region: str = 
 
 
 @mcp.tool()
-async def fetch_content(url: str, ctx: Context, start_index: int = 0, max_length: int = 8000) -> str:
+async def fetch_content(
+    url: str,
+    ctx: Context,
+    start_index: int = 0,
+    max_length: int = 8000,
+    backend: Optional[str] = None,
+) -> str:
     """Fetch and extract the main text content from a webpage. Strips out navigation, headers, footers, scripts, and styles to return clean readable text. Use this after searching to read the full content of a specific result. Supports pagination for long pages via start_index and max_length.
 
     Args:
         url: The full URL of the webpage to fetch (must start with http:// or https://).
         start_index: Character offset to start reading from (default: 0). Use this to paginate through long content.
         max_length: Maximum number of characters to return (default: 8000). Increase for more content per request or decrease for quicker responses.
+        backend: Optional override of the server's default fetch backend for this single call. One of 'httpx' (lightweight), 'curl' (Chrome TLS impersonation, bypasses many bot filters; requires the [browser] extra), or 'auto' (try httpx, fall back to curl on block). Leave unset to use the server default.
         ctx: MCP context for logging.
     """
-    return await fetcher.fetch_and_parse(url, ctx, start_index, max_length)
+    return await fetcher.fetch_and_parse(url, ctx, start_index, max_length, backend=backend)
 
 
 def main():
+    global fetcher
     parser = argparse.ArgumentParser(description="DuckDuckGo MCP Server")
     parser.add_argument(
         "--transport",
@@ -307,7 +431,24 @@ def main():
         default="stdio",
         help="Transport protocol to use (default: stdio)",
     )
+    parser.add_argument(
+        "--fetch-backend",
+        choices=list(SUPPORTED_FETCH_BACKENDS),
+        default="httpx",
+        help=(
+            "Default HTTP backend for fetch_content. 'httpx' (default) is lightweight. "
+            "'curl' uses curl_cffi with Chrome TLS impersonation to bypass bot filters "
+            "(Cloudflare Bot Management, etc.) and requires the [browser] extra. "
+            "'auto' tries httpx first and falls back to curl on 403 / Cloudflare "
+            "challenge. Individual fetch_content calls can override this via their "
+            "'backend' argument."
+        ),
+    )
     args = parser.parse_args()
+    # Reconfigure the module-level fetcher with the chosen backend.
+    # Safe because tool invocations look up `fetcher` at call time (late binding).
+    fetcher = WebContentFetcher(backend=args.fetch_backend)
+    print(f"  Fetch backend: {fetcher.default_backend}", file=sys.stderr)
     mcp.run(transport=args.transport)
 
 

--- a/src/duckduckgo_mcp_server/test_e2e.py
+++ b/src/duckduckgo_mcp_server/test_e2e.py
@@ -114,6 +114,28 @@ async def test_search_tool_e2e(ddg_html_factory):
 
 
 @pytest.mark.asyncio
+async def test_fetch_content_tool_accepts_backend_param(local_http_server):
+    """The fetch_content tool should accept a per-call `backend` argument."""
+    html = "<html><body><h1>Backend Param Test</h1></body></html>"
+    url = local_http_server(html)
+
+    async with create_connected_server_and_client_session(mcp_app) as client:
+        result = await client.call_tool("fetch_content", {"url": url, "backend": "httpx"})
+        text = result.content[0].text
+        assert "Backend Param Test" in text
+
+
+@pytest.mark.asyncio
+async def test_fetch_content_tool_lists_backend_in_schema():
+    """The `backend` parameter should be advertised in fetch_content's inputSchema."""
+    async with create_connected_server_and_client_session(mcp_app) as client:
+        tools_result = await client.list_tools()
+        fetch_tool = next(t for t in tools_result.tools if t.name == "fetch_content")
+        props = fetch_tool.inputSchema.get("properties", {})
+        assert "backend" in props, f"expected 'backend' in fetch_content inputSchema, got: {list(props)}"
+
+
+@pytest.mark.asyncio
 async def test_search_tool_handles_errors():
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(side_effect=httpx.TimeoutException("timeout"))

--- a/src/duckduckgo_mcp_server/test_server.py
+++ b/src/duckduckgo_mcp_server/test_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import threading
 from datetime import datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -14,8 +15,15 @@ from duckduckgo_mcp_server.server import (
     DuckDuckGoSearcher,
     SafeSearchMode,
     SearchResult,
+    SUPPORTED_FETCH_BACKENDS,
     WebContentFetcher,
 )
+
+try:
+    import curl_cffi  # noqa: F401
+    HAS_CURL_CFFI = True
+except ImportError:
+    HAS_CURL_CFFI = False
 
 
 class DummyCtx:
@@ -226,6 +234,37 @@ class TestDuckDuckGoSearcherParsing(unittest.TestCase):
         self.assertEqual(results, [])
 
 
+def _serve_html(html_content):
+    """Spin up a throwaway local HTTP server serving html_content. Returns (url, stop_fn)."""
+
+    class SimpleHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write(html_content.encode("utf-8"))
+
+        def log_message(self, format, *args):
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), SimpleHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+
+    def stop():
+        server.shutdown()
+        thread.join()
+
+    return url, stop
+
+
+# Backends to exercise in the parameterized fetcher tests. curl is only included
+# when curl_cffi is actually installed (the optional [browser] extra).
+_FETCH_BACKENDS_FOR_TESTING = ["httpx"] + (["curl"] if HAS_CURL_CFFI else [])
+
+
 class TestWebContentFetcher(unittest.TestCase):
     def test_fetch_and_parse_extracts_clean_text(self):
         html_content = """
@@ -245,119 +284,270 @@ class TestWebContentFetcher(unittest.TestCase):
         </html>
         """
 
-        class SimpleHandler(BaseHTTPRequestHandler):
-            def do_GET(self):
-                self.send_response(200)
-                self.send_header("Content-type", "text/html")
-                self.end_headers()
-                self.wfile.write(html_content.encode("utf-8"))
-
-            def log_message(self, format, *args):
-                return
-
-        server = HTTPServer(("127.0.0.1", 0), SimpleHandler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-
+        url, stop = _serve_html(html_content)
         try:
-            fetcher = WebContentFetcher()
-            url = f"http://127.0.0.1:{server.server_address[1]}"
-            text = asyncio.run(fetcher.fetch_and_parse(url, DummyCtx()))
-
-            self.assertIn("Sample Heading", text)
-            self.assertIn("Some meaningful paragraph.", text)
-            self.assertNotIn("Navigation", text)
-            self.assertNotIn("console.log", text)
+            for backend in _FETCH_BACKENDS_FOR_TESTING:
+                with self.subTest(backend=backend):
+                    fetcher = WebContentFetcher(backend=backend)
+                    text = asyncio.run(fetcher.fetch_and_parse(url, DummyCtx()))
+                    self.assertIn("Sample Heading", text)
+                    self.assertIn("Some meaningful paragraph.", text)
+                    self.assertNotIn("Navigation", text)
+                    self.assertNotIn("console.log", text)
         finally:
-            server.shutdown()
-            thread.join()
+            stop()
 
     def test_fetch_and_parse_pagination(self):
         html_content = "<html><body><p>" + "A" * 100 + "</p></body></html>"
-
-        class SimpleHandler(BaseHTTPRequestHandler):
-            def do_GET(self):
-                self.send_response(200)
-                self.send_header("Content-type", "text/html")
-                self.end_headers()
-                self.wfile.write(html_content.encode("utf-8"))
-
-            def log_message(self, format, *args):
-                return
-
-        server = HTTPServer(("127.0.0.1", 0), SimpleHandler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-
+        url, stop = _serve_html(html_content)
         try:
-            fetcher = WebContentFetcher()
-            url = f"http://127.0.0.1:{server.server_address[1]}"
-
-            # Fetch first 50 chars
-            text = asyncio.run(fetcher.fetch_and_parse(url, DummyCtx(), start_index=0, max_length=50))
-            self.assertIn("start_index=50 to see more", text)
-            self.assertIn("of 100 total", text)
-
-            # Fetch from offset 50
-            text = asyncio.run(fetcher.fetch_and_parse(url, DummyCtx(), start_index=50, max_length=50))
-            self.assertNotIn("to see more", text)
-            self.assertIn("of 100 total", text)
+            for backend in _FETCH_BACKENDS_FOR_TESTING:
+                with self.subTest(backend=backend):
+                    fetcher = WebContentFetcher(backend=backend)
+                    # Fetch first 50 chars
+                    text = asyncio.run(
+                        fetcher.fetch_and_parse(url, DummyCtx(), start_index=0, max_length=50)
+                    )
+                    self.assertIn("start_index=50 to see more", text)
+                    self.assertIn("of 100 total", text)
+                    # Fetch from offset 50
+                    text = asyncio.run(
+                        fetcher.fetch_and_parse(url, DummyCtx(), start_index=50, max_length=50)
+                    )
+                    self.assertNotIn("to see more", text)
+                    self.assertIn("of 100 total", text)
         finally:
-            server.shutdown()
-            thread.join()
+            stop()
+
+
+def _patch_backend_client(backend, *, get_return_value=None, get_side_effect=None):
+    """Return a context manager that patches the HTTP client for the given backend.
+
+    - "httpx": patches `httpx.AsyncClient`.
+    - "curl":  patches `curl_cffi.requests.AsyncSession`.
+    Both are patched with an AsyncMock whose .get() uses the provided return/side-effect.
+    """
+    mock_client = AsyncMock()
+    if get_side_effect is not None:
+        mock_client.get = AsyncMock(side_effect=get_side_effect)
+    else:
+        mock_client.get = AsyncMock(return_value=get_return_value)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    if backend == "httpx":
+        return patch("httpx.AsyncClient", return_value=mock_client)
+    elif backend == "curl":
+        return patch("curl_cffi.requests.AsyncSession", return_value=mock_client)
+    raise ValueError(f"no patcher for backend {backend!r}")
 
 
 class TestWebContentFetcherErrors(unittest.TestCase):
     def test_fetch_returns_error_on_timeout(self):
-        fetcher = WebContentFetcher()
-        ctx = DummyCtx()
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("httpx.AsyncClient", return_value=mock_client):
-            result = asyncio.run(fetcher.fetch_and_parse("https://example.com", ctx))
-        self.assertIn("timed out", result)
+        for backend in _FETCH_BACKENDS_FOR_TESTING:
+            with self.subTest(backend=backend):
+                fetcher = WebContentFetcher(backend=backend)
+                # Use an exception whose type-name triggers the server's curl-path
+                # error handling without needing curl_cffi's exception hierarchy.
+                exc = httpx.TimeoutException("timed out") if backend == "httpx" else TimeoutError("timed out")
+                with _patch_backend_client(backend, get_side_effect=exc):
+                    result = asyncio.run(
+                        fetcher.fetch_and_parse("https://example.com", DummyCtx())
+                    )
+                self.assertTrue(result.startswith("Error"), f"got: {result!r}")
+                self.assertIn("timed out", result.lower())
 
     def test_fetch_returns_error_on_http_error(self):
-        fetcher = WebContentFetcher()
+        for backend in _FETCH_BACKENDS_FOR_TESTING:
+            with self.subTest(backend=backend):
+                fetcher = WebContentFetcher(backend=backend)
+                mock_resp = MagicMock()
+                mock_resp.status_code = 500
+                mock_resp.request = MagicMock()
+                if backend == "httpx":
+                    err = httpx.HTTPStatusError("server error", request=mock_resp.request, response=mock_resp)
+                else:
+                    err = RuntimeError("curl http 500")
+                mock_resp.raise_for_status = MagicMock(side_effect=err)
+                with _patch_backend_client(backend, get_return_value=mock_resp):
+                    result = asyncio.run(
+                        fetcher.fetch_and_parse("https://example.com", DummyCtx())
+                    )
+                self.assertTrue(result.startswith("Error"), f"got: {result!r}")
+
+    def test_fetch_handles_malformed_html(self):
+        for backend in _FETCH_BACKENDS_FOR_TESTING:
+            with self.subTest(backend=backend):
+                fetcher = WebContentFetcher(backend=backend)
+                mock_resp = MagicMock()
+                mock_resp.text = "<<<not valid>>>"
+                mock_resp.status_code = 200
+                mock_resp.raise_for_status = MagicMock()
+                with _patch_backend_client(backend, get_return_value=mock_resp):
+                    result = asyncio.run(
+                        fetcher.fetch_and_parse("https://example.com", DummyCtx())
+                    )
+                # Should not crash - returns some text (possibly empty or with metadata)
+                self.assertIsInstance(result, str)
+
+
+class TestWebContentFetcherBackend(unittest.TestCase):
+    def test_init_rejects_unknown_backend(self):
+        with self.assertRaises(ValueError):
+            WebContentFetcher(backend="bogus")
+
+    def test_default_backend_is_httpx(self):
+        self.assertEqual(WebContentFetcher().default_backend, "httpx")
+
+    def test_supported_backends_tuple(self):
+        self.assertEqual(SUPPORTED_FETCH_BACKENDS, ("httpx", "curl", "auto"))
+
+    def test_per_call_backend_overrides_default(self):
+        """default=httpx, pass backend='curl' per-call → curl path is exercised."""
+        fetcher = WebContentFetcher(backend="httpx")
         ctx = DummyCtx()
+        called = {"httpx": False, "curl": False}
+
+        async def fake_httpx(url):
+            called["httpx"] = True
+            return "<html><body><p>from httpx</p></body></html>"
+
+        async def fake_curl(url):
+            called["curl"] = True
+            return "<html><body><p>from curl</p></body></html>"
+
+        with patch.object(fetcher, "_fetch_httpx", side_effect=fake_httpx), \
+             patch.object(fetcher, "_fetch_curl", side_effect=fake_curl):
+            text = asyncio.run(
+                fetcher.fetch_and_parse("https://example.com", ctx, backend="curl")
+            )
+
+        self.assertFalse(called["httpx"])
+        self.assertTrue(called["curl"])
+        self.assertIn("from curl", text)
+
+    def test_per_call_unknown_backend_returns_error(self):
+        fetcher = WebContentFetcher()
+        result = asyncio.run(
+            fetcher.fetch_and_parse("https://example.com", DummyCtx(), backend="bogus")
+        )
+        self.assertIn("Unknown fetch backend", result)
+
+    def test_curl_backend_missing_dependency_error(self):
+        """If curl_cffi isn't importable, curl backend returns a helpful install hint."""
+        fetcher = WebContentFetcher(backend="curl")
+        # Make the lazy `from curl_cffi.requests import AsyncSession` raise ImportError.
+        with patch.dict(sys.modules, {"curl_cffi": None, "curl_cffi.requests": None}):
+            result = asyncio.run(
+                fetcher.fetch_and_parse("https://example.com", DummyCtx())
+            )
+        self.assertIn("Error", result)
+        self.assertIn("pip install", result)
+        self.assertIn("browser", result)
+
+
+class TestWebContentFetcherAutoFallback(unittest.TestCase):
+    def test_auto_uses_httpx_when_successful(self):
+        fetcher = WebContentFetcher(backend="auto")
+        called = {"httpx": 0, "curl": 0}
+
+        async def fake_httpx(url):
+            called["httpx"] += 1
+            return "<html><body><p>ok from httpx</p></body></html>"
+
+        async def fake_curl(url):
+            called["curl"] += 1
+            return "<html><body><p>from curl</p></body></html>"
+
+        with patch.object(fetcher, "_fetch_httpx", side_effect=fake_httpx), \
+             patch.object(fetcher, "_fetch_curl", side_effect=fake_curl):
+            text = asyncio.run(fetcher.fetch_and_parse("https://example.com", DummyCtx()))
+
+        self.assertEqual(called["httpx"], 1)
+        self.assertEqual(called["curl"], 0)
+        self.assertIn("ok from httpx", text)
+
+    def test_auto_falls_back_on_403(self):
+        fetcher = WebContentFetcher(backend="auto")
+        called = {"curl": 0}
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        err = httpx.HTTPStatusError("forbidden", request=MagicMock(), response=mock_resp)
+
+        async def fake_httpx(url):
+            raise err
+
+        async def fake_curl(url):
+            called["curl"] += 1
+            return "<html><body><p>rescued by curl</p></body></html>"
+
+        with patch.object(fetcher, "_fetch_httpx", side_effect=fake_httpx), \
+             patch.object(fetcher, "_fetch_curl", side_effect=fake_curl):
+            text = asyncio.run(fetcher.fetch_and_parse("https://example.com", DummyCtx()))
+
+        self.assertEqual(called["curl"], 1)
+        self.assertIn("rescued by curl", text)
+
+    def test_auto_falls_back_on_cloudflare_challenge(self):
+        fetcher = WebContentFetcher(backend="auto")
+        called = {"curl": 0}
+
+        async def fake_httpx(url):
+            return (
+                "<html><head><title>Just a moment...</title></head>"
+                "<body>Enable JavaScript and cookies to continue</body></html>"
+            )
+
+        async def fake_curl(url):
+            called["curl"] += 1
+            return "<html><body><p>real content</p></body></html>"
+
+        with patch.object(fetcher, "_fetch_httpx", side_effect=fake_httpx), \
+             patch.object(fetcher, "_fetch_curl", side_effect=fake_curl):
+            text = asyncio.run(fetcher.fetch_and_parse("https://example.com", DummyCtx()))
+
+        self.assertEqual(called["curl"], 1)
+        self.assertIn("real content", text)
+
+    def test_auto_reraises_non_403_http_error(self):
+        """A 500 under auto should NOT trigger curl fallback — only 403/CF signals do."""
+        fetcher = WebContentFetcher(backend="auto")
+        called = {"curl": 0}
 
         mock_resp = MagicMock()
         mock_resp.status_code = 500
-        mock_resp.request = MagicMock()
-        error = httpx.HTTPStatusError("server error", request=mock_resp.request, response=mock_resp)
+        err = httpx.HTTPStatusError("server error", request=MagicMock(), response=mock_resp)
 
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_resp)
-        mock_resp.raise_for_status = MagicMock(side_effect=error)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        async def fake_httpx(url):
+            raise err
 
-        with patch("httpx.AsyncClient", return_value=mock_client):
-            result = asyncio.run(fetcher.fetch_and_parse("https://example.com", ctx))
-        self.assertIn("Error", result)
+        async def fake_curl(url):
+            called["curl"] += 1
+            return "<html></html>"
 
-    def test_fetch_handles_malformed_html(self):
-        fetcher = WebContentFetcher()
-        ctx = DummyCtx()
+        with patch.object(fetcher, "_fetch_httpx", side_effect=fake_httpx), \
+             patch.object(fetcher, "_fetch_curl", side_effect=fake_curl):
+            result = asyncio.run(fetcher.fetch_and_parse("https://example.com", DummyCtx()))
 
-        mock_resp = MagicMock()
-        mock_resp.text = "<<<not valid>>>"
-        mock_resp.status_code = 200
-        mock_resp.raise_for_status = MagicMock()
+        self.assertEqual(called["curl"], 0)
+        self.assertTrue(result.startswith("Error"))
 
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_resp)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("httpx.AsyncClient", return_value=mock_client):
-            result = asyncio.run(fetcher.fetch_and_parse("https://example.com", ctx))
-        # Should not crash - returns some text (possibly empty or with metadata)
-        self.assertIsInstance(result, str)
+class TestMainCliArgs(unittest.TestCase):
+    def test_main_parses_fetch_backend_flag(self):
+        with patch.object(sys, "argv", ["duckduckgo-mcp-server", "--fetch-backend", "auto"]), \
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp:
+            duckduckgo_mcp_server.server.main()
+            mock_mcp.run.assert_called_once()
+        self.assertEqual(duckduckgo_mcp_server.server.fetcher.default_backend, "auto")
+
+    def test_main_defaults_to_httpx(self):
+        with patch.object(sys, "argv", ["duckduckgo-mcp-server"]), \
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp:
+            duckduckgo_mcp_server.server.main()
+            mock_mcp.run.assert_called_once()
+        self.assertEqual(duckduckgo_mcp_server.server.fetcher.default_backend, "httpx")
 
 
 class TestConfiguration(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -238,14 +238,52 @@ wheels = [
 ]
 
 [[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
+]
+
+[[package]]
 name = "duckduckgo-mcp-server"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "httpcore" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+]
+
+[package.optional-dependencies]
+browser = [
+    { name = "curl-cffi" },
 ]
 
 [package.dev-dependencies]
@@ -258,10 +296,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.3" },
+    { name = "curl-cffi", marker = "extra == 'browser'", specifier = ">=0.7.0" },
     { name = "httpcore", specifier = ">=1.0.8" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
 ]
+provides-extras = ["browser"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds a configurable HTTP backend for `fetch_content` so the server can reach pages that block Python's distinctive TLS fingerprint (e.g., Cloudflare Bot Management, various HAProxy bot filters) regardless of User-Agent. Default behavior is unchanged.

## Why

`httpx` (and most pure-Python HTTP clients) produce a TLS ClientHello that bot-detection services flag, so `fetch_content` 403s on a meaningful number of otherwise-public URLs — even with a legitimate browser UA. Using `curl_cffi` (a libcurl-impersonate binding) to forge a Chrome 131 TLS handshake and HTTP/2 frame ordering passes those checks without needing a headless browser.

Sites gated by active JavaScript challenges still require a real browser and remain out of scope; this change handles the common TLS-fingerprint case only.

## What's new

Three backends for `fetch_content`:

| Value  | Behavior                                                                 | Needs `[browser]` |
| ------ | ------------------------------------------------------------------------ | ----------------- |
| `httpx` | Lightweight async HTTP. **Default.** Works on most sites.                | no                |
| `curl` | `curl_cffi` with Chrome 131 TLS impersonation.                           | yes               |
| `auto` | Tries `httpx`; falls back to `curl` on 403 or a Cloudflare challenge body. | yes               |

Two ways to configure it:

1. **Server-wide default** — `--fetch-backend {httpx,curl,auto}` CLI flag, defaults to `httpx`.
2. **Per-call override** — `fetch_content` gains an optional `backend` argument so MCP clients can choose per fetch.

`search` continues to use `httpx` unconditionally (DuckDuckGo's search endpoint doesn't require impersonation).

## Non-breaking

- Default backend is `httpx`. No behavior change for existing users.
- `curl_cffi` is delivered as an **optional** `[browser]` extra and lazy-imported. Default installs don't pull it in. Selecting `curl`/`auto` without the extra returns a clear `pip install 'duckduckgo-mcp-server[browser]'` hint instead of a traceback.
- No new required dependencies, no changes to `requires-python`, no changes to the existing tool signatures beyond an optional keyword-only arg.

## Tests

- `WebContentFetcher` happy-path and error tests parameterized over both backends via `subTest(backend=...)`; curl subtests auto-skip when `curl_cffi` isn't installed.
- New unit tests for:
  - Backend validation (`__init__` rejects unknown values)
  - Default is `httpx`
  - Per-call override
  - Per-call unknown backend → error
  - Missing-dependency install hint
  - `auto` happy path (no fallback when httpx succeeds)
  - `auto` falls back on 403
  - `auto` falls back on Cloudflare challenge body (`cf-mitigated`, "Just a moment…", etc.)
  - `auto` does **not** fall back on non-403 HTTP errors
  - `--fetch-backend` CLI flag parsing (default + explicit)
- New e2e tests: `fetch_content` accepts the `backend` parameter and advertises it in its `inputSchema`.

Full suite: 39 tests + 10 subtests passing locally on Python 3.13.

## Try it

```bash
# Default — unchanged
uvx duckduckgo-mcp-server

# TLS impersonation on every fetch
uvx --with "duckduckgo-mcp-server[browser]" duckduckgo-mcp-server --fetch-backend curl

# Try plain httpx first, fall back to curl on block
uvx --with "duckduckgo-mcp-server[browser]" duckduckgo-mcp-server --fetch-backend auto