### PR TITLE
feat: add --host and --port arguments for network transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ uvx duckduckgo-mcp-server --transport sse
 uvx duckduckgo-mcp-server --transport streamable-http
 ```
 
-The default transport is `stdio`, which is used by Claude Desktop and Claude Code.
+You may also pass an explicit host and port for the server to listen on via the `--host` and `--port` argument flags. If these flags are passed to the server when the specified transport is `stdio`, the server will fail to start.
+
+The default transport is `stdio`, which is used by Claude Desktop and Claude Code. 
 
 ### Development
 

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -307,8 +307,19 @@ def main():
         default="stdio",
         help="Transport protocol to use (default: stdio)",
     )
+
+    parser.add_argument("--host", help="Host to bind to")
+    parser.add_argument("--port", type=int, help="Port to bind to")
+
     args = parser.parse_args()
-    mcp.run(transport=args.transport)
+
+    if args.transport == "stdio" and (args.host is not None or args.port is not None):
+        parser.error("The transport `stdio` does not allow --host or --port flags.")
+
+    if args.transport in ("sse", "streamable-http"):
+        mcp.run(transport=args.transport, host=args.host, port=args.port)
+    else:
+        mcp.run(transport=args.transport)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Introduce `--host` and `--port` CLI flags to configure the server's listening address.
- Implement validation to ensure network flags are not used with `stdio` transport.
- Update `mcp.run` to pass these parameters when using `sse` or `streamable-http`.
- Update documentation to reflect new configuration options and expected error behavior.

This allows the server to be used more effectively in containerized or remote environments where binding to specific interfaces (e.g., 0.0.0.0) is required.