### PR TITLE
Support multiple HTTP transports and add POST /sse compatibility

### DIFF
--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -428,11 +428,17 @@ async def fetch_content(
 
 def main():
     global fetcher
+    from starlette.applications import Starlette
+    from starlette.middleware.cors import CORSMiddleware
+    from starlette.routing import BaseRoute, Route
+    import uvicorn
+
     parser = argparse.ArgumentParser(description="DuckDuckGo MCP Server")
     parser.add_argument(
         "--transport",
+        nargs="+",
         choices=["stdio", "sse", "streamable-http"],
-        default="stdio",
+        default=["stdio"],
         help="Transport protocol to use (default: stdio)",
     )
     parser.add_argument(
@@ -450,30 +456,109 @@ def main():
     )
     parser.add_argument(
         "--host",
+        default="127.0.0.1",
         help="Bind address for sse / streamable-http transports (default: 127.0.0.1).",
     )
     parser.add_argument(
         "--port",
         type=int,
+        default=8000,
         help="Bind port for sse / streamable-http transports (default: 8000).",
     )
     args = parser.parse_args()
 
-    if args.transport == "stdio" and (args.host is not None or args.port is not None):
-        parser.error("--host / --port are only valid with --transport sse or streamable-http")
+    transports = set(args.transport)
 
-    if args.host is not None:
-        mcp.settings.host = args.host
-    if args.port is not None:
-        mcp.settings.port = args.port
+    if "stdio" in transports and len(transports) > 1:
+        parser.error("Cannot mix stdio with HTTP transports")
 
     # Reconfigure the module-level fetcher with the chosen backend.
-    # Safe because tool invocations look up `fetcher` at call time (late binding).
     fetcher = WebContentFetcher(backend=args.fetch_backend)
     print(f"  Fetch backend: {fetcher.default_backend}", file=sys.stderr)
-    if args.transport in ("sse", "streamable-http"):
-        print(f"  Bind address: {mcp.settings.host}:{mcp.settings.port}", file=sys.stderr)
-    mcp.run(transport=args.transport)
+
+    if transports == {"stdio"}:
+        mcp.run(transport="stdio")
+    elif transports.issubset({"sse", "streamable-http"}):
+        mcp.settings.json_response = True
+        mcp.settings.host = args.host
+        mcp.settings.port = args.port
+
+        # SSE and Streamable HTTP app setup
+        sse_app = mcp.sse_app()
+        http_app = mcp.streamable_http_app()
+
+        # Find the streamable_http_app handler (needed for POST /sse compatibility)
+        http_handler = None
+        for route in http_app.routes:
+            if (
+                isinstance(route, Route)
+                and route.path == mcp.settings.streamable_http_path
+            ):
+                http_handler = route.endpoint
+                break
+
+        # Create a combined routes list
+        combined_routes: list[BaseRoute] = []
+
+        # 1. Compatibility route: POST /sse -> StreamableHTTP (for llama.cpp etc.)
+        if http_handler:
+            combined_routes.append(
+                Route(mcp.settings.sse_path, http_handler, methods=["POST"])
+            )
+            print(
+                f"Added POST support to {mcp.settings.sse_path} for Streamable HTTP compatibility"
+            )
+
+        # 2. Regular routes
+        if "sse" in transports:
+            combined_routes.extend(sse_app.routes)
+
+        if "streamable-http" in transports:
+            for route in http_app.routes:
+                if isinstance(route, Route):
+                    if not any(
+                        isinstance(r, Route) and r.path == route.path
+                        for r in combined_routes
+                    ):
+                        combined_routes.append(route)
+                else:
+                    combined_routes.append(route)
+
+        # Create the Starlette app with combined routes
+        app = Starlette(
+            routes=combined_routes,
+            lifespan=http_app.router.lifespan_context,
+        )
+
+        # Add CORS middleware
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+            expose_headers=["Mcp-Session-Id"],
+        )
+
+        print(
+            f"Starting DuckDuckGo MCP Server with {' and '.join(transports)} transport"
+        )
+        if "sse" in transports:
+            print(
+                f"SSE endpoint: http://{args.host}:{args.port}{mcp.settings.sse_path}"
+            )
+        if "streamable-http" in transports:
+            print(
+                f"Streamable HTTP endpoint: http://{args.host}:{args.port}{mcp.settings.streamable_http_path}"
+            )
+
+        uvicorn.run(app, host=args.host, port=args.port)
+    else:
+        print(
+            f"Error: Invalid transport combination: {transports}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -456,13 +456,13 @@ def main():
     )
     parser.add_argument(
         "--host",
-        default="127.0.0.1",
+        default=None,
         help="Bind address for sse / streamable-http transports (default: 127.0.0.1).",
     )
     parser.add_argument(
         "--port",
         type=int,
-        default=8000,
+        default=None,
         help="Bind port for sse / streamable-http transports (default: 8000).",
     )
     args = parser.parse_args()
@@ -472,6 +472,9 @@ def main():
     if "stdio" in transports and len(transports) > 1:
         parser.error("Cannot mix stdio with HTTP transports")
 
+    if transports == {"stdio"} and (args.host is not None or args.port is not None):
+        parser.error("--host / --port are only valid with --transport sse or streamable-http")
+
     # Reconfigure the module-level fetcher with the chosen backend.
     fetcher = WebContentFetcher(backend=args.fetch_backend)
     print(f"  Fetch backend: {fetcher.default_backend}", file=sys.stderr)
@@ -479,25 +482,16 @@ def main():
     if transports == {"stdio"}:
         mcp.run(transport="stdio")
     elif transports.issubset({"sse", "streamable-http"}):
-        mcp.settings.json_response = True
-        mcp.settings.host = args.host
-        mcp.settings.port = args.port
+        host = args.host or "127.0.0.1"
+        port = args.port or 8000
+        mcp.settings.host = host
+        mcp.settings.port = port
 
         # SSE and Streamable HTTP app setup
         sse_app = mcp.sse_app()
         http_app = mcp.streamable_http_app()
 
-        # Find the streamable_http_app handler (needed for POST /sse compatibility)
-        http_handler = None
-        for route in http_app.routes:
-            if (
-                isinstance(route, Route)
-                and route.path == mcp.settings.streamable_http_path
-            ):
-                http_handler = route.endpoint
-                break
-
-        # Create a combined routes list with proper deduplication
+        # Create combined routes with proper deduplication
         combined_routes: list[BaseRoute] = []
         added_routes: set[tuple[str, tuple[str, ...]]] = set()
 
@@ -505,19 +499,6 @@ def main():
             methods = tuple(sorted(route.methods or ["GET"]))
             return (route.path, methods)
 
-        # 1. Compatibility route: POST /sse -> StreamableHTTP (for llama.cpp etc.)
-        if http_handler:
-            compat_route = Route(
-                mcp.settings.sse_path, http_handler, methods=["POST"]
-            )
-            key = _route_key(compat_route)
-            combined_routes.append(compat_route)
-            added_routes.add(key)
-            print(
-                f"Added POST support to {mcp.settings.sse_path} for Streamable HTTP compatibility"
-            )
-
-        # 2. Regular routes (dedupe by (path, methods))
         for app_routes in [
             sse_app.routes if "sse" in transports else [],
             http_app.routes if "streamable-http" in transports else [],
@@ -531,20 +512,31 @@ def main():
                 else:
                     combined_routes.append(route)
 
-        # Create the Starlette app with combined routes
-        # Prefer http_app lifespan if available (it has more complete lifecycle)
-        lifespan = (
-            http_app.router.lifespan_context
-            if "streamable-http" in transports
-            else sse_app.router.lifespan_context
-        )
+        # Combine lifespan contexts when both transports are active
+        sse_lifespan = sse_app.router.lifespan_context
+        http_lifespan = http_app.router.lifespan_context
+
+        if "streamable-http" in transports and "sse" in transports:
+            from contextlib import asynccontextmanager
+
+            @asynccontextmanager
+            async def _combined_lifespan(app):
+                async with sse_lifespan(app):
+                    async with http_lifespan(app):
+                        yield
+
+            lifespan = _combined_lifespan
+        elif "streamable-http" in transports:
+            lifespan = http_lifespan
+        else:
+            lifespan = sse_lifespan
+
         app = Starlette(routes=combined_routes, lifespan=lifespan)
 
-        # Add CORS middleware
+        # Add CORS middleware for browser-based MCP clients
         app.add_middleware(
             CORSMiddleware,
             allow_origins=["*"],
-            allow_credentials=True,
             allow_methods=["*"],
             allow_headers=["*"],
             expose_headers=["Mcp-Session-Id"],
@@ -555,21 +547,14 @@ def main():
         )
         if "sse" in transports:
             print(
-                f"SSE endpoint: http://{args.host}:{args.port}{mcp.settings.sse_path}"
+                f"SSE endpoint: http://{host}:{port}{mcp.settings.sse_path}"
             )
         if "streamable-http" in transports:
             print(
-                f"Streamable HTTP endpoint: http://{args.host}:{args.port}{mcp.settings.streamable_http_path}"
+                f"Streamable HTTP endpoint: http://{host}:{port}{mcp.settings.streamable_http_path}"
             )
 
-        uvicorn.run(app, host=args.host, port=args.port)
-    else:
-        print(
-            f"Error: Invalid transport combination: {transports}. "
-            "Valid options: stdio | sse | streamable-http | sse streamable-http",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        uvicorn.run(app, host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -497,38 +497,48 @@ def main():
                 http_handler = route.endpoint
                 break
 
-        # Create a combined routes list
+        # Create a combined routes list with proper deduplication
         combined_routes: list[BaseRoute] = []
+        added_routes: set[tuple[str, tuple[str, ...]]] = set()
+
+        def _route_key(route: Route) -> tuple[str, tuple[str, ...]]:
+            methods = tuple(sorted(route.methods or ["GET"]))
+            return (route.path, methods)
 
         # 1. Compatibility route: POST /sse -> StreamableHTTP (for llama.cpp etc.)
         if http_handler:
-            combined_routes.append(
-                Route(mcp.settings.sse_path, http_handler, methods=["POST"])
+            compat_route = Route(
+                mcp.settings.sse_path, http_handler, methods=["POST"]
             )
+            key = _route_key(compat_route)
+            combined_routes.append(compat_route)
+            added_routes.add(key)
             print(
                 f"Added POST support to {mcp.settings.sse_path} for Streamable HTTP compatibility"
             )
 
-        # 2. Regular routes
-        if "sse" in transports:
-            combined_routes.extend(sse_app.routes)
-
-        if "streamable-http" in transports:
-            for route in http_app.routes:
+        # 2. Regular routes (dedupe by (path, methods))
+        for app_routes in [
+            sse_app.routes if "sse" in transports else [],
+            http_app.routes if "streamable-http" in transports else [],
+        ]:
+            for route in app_routes:
                 if isinstance(route, Route):
-                    if not any(
-                        isinstance(r, Route) and r.path == route.path
-                        for r in combined_routes
-                    ):
+                    key = _route_key(route)
+                    if key not in added_routes:
                         combined_routes.append(route)
+                        added_routes.add(key)
                 else:
                     combined_routes.append(route)
 
         # Create the Starlette app with combined routes
-        app = Starlette(
-            routes=combined_routes,
-            lifespan=http_app.router.lifespan_context,
+        # Prefer http_app lifespan if available (it has more complete lifecycle)
+        lifespan = (
+            http_app.router.lifespan_context
+            if "streamable-http" in transports
+            else sse_app.router.lifespan_context
         )
+        app = Starlette(routes=combined_routes, lifespan=lifespan)
 
         # Add CORS middleware
         app.add_middleware(
@@ -555,7 +565,8 @@ def main():
         uvicorn.run(app, host=args.host, port=args.port)
     else:
         print(
-            f"Error: Invalid transport combination: {transports}",
+            f"Error: Invalid transport combination: {transports}. "
+            "Valid options: stdio | sse | streamable-http | sse streamable-http",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/src/duckduckgo_mcp_server/test_server.py
+++ b/src/duckduckgo_mcp_server/test_server.py
@@ -601,24 +601,6 @@ class TestMainCliArgs(unittest.TestCase):
             self.assertEqual(call_kwargs["host"], "0.0.0.0")
             self.assertEqual(call_kwargs["port"], 7070)
 
-    def test_main_dual_transport_adds_post_sse_route(self):
-        argv = ["duckduckgo-mcp-server", "--transport", "sse", "streamable-http"]
-        with patch.object(sys, "argv", argv), \
-             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
-             patch("uvicorn.run") as mock_uvicorn_run:
-            _setup_mock_mcp_for_http(mock_mcp)
-            async def handler(request):
-                pass
-            mcp_route = StarletteRoute("/mcp", handler, methods=["GET"])
-            mock_mcp.streamable_http_app.return_value.routes = [mcp_route]
-            duckduckgo_mcp_server.server.main()
-            app = mock_uvicorn_run.call_args[0][0]
-            post_sse_routes = [
-                r for r in app.routes
-                if isinstance(r, StarletteRoute) and r.path == "/sse" and "POST" in r.methods
-            ]
-            self.assertEqual(len(post_sse_routes), 1)
-
     def test_main_route_dedup_prevents_duplicates(self):
         argv = ["duckduckgo-mcp-server", "--transport", "sse", "streamable-http"]
         async def handler(request):
@@ -664,35 +646,52 @@ class TestMainCliArgs(unittest.TestCase):
         for transports, expected_lifespan_name in [
             (["sse"], "sse_lifespan"),
             (["streamable-http"], "http_lifespan"),
-            (["sse", "streamable-http"], "http_lifespan"),
+            (["sse", "streamable-http"], "combined"),
         ]:
             with self.subTest(transports=transports):
                 argv = ["duckduckgo-mcp-server", "--transport"] + transports
                 with patch.object(sys, "argv", argv), \
                      patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
                      patch("uvicorn.run") as mock_uvicorn_run:
-                    _setup_mock_mcp_for_http(mock_mcp)
+                    sse_app, http_app = _setup_mock_mcp_for_http(mock_mcp)
                     duckduckgo_mcp_server.server.main()
                     app = mock_uvicorn_run.call_args[0][0]
                     lifespan = app.router.lifespan_context
-                    self.assertEqual(
-                        lifespan._mock_name,
-                        expected_lifespan_name,
-                        f"Wrong lifespan for {transports}",
-                    )
+                    if expected_lifespan_name == "combined":
+                        self.assertIsNot(lifespan, sse_app.router.lifespan_context)
+                        self.assertIsNot(lifespan, http_app.router.lifespan_context)
+                    else:
+                        self.assertEqual(
+                            lifespan._mock_name,
+                            expected_lifespan_name,
+                            f"Wrong lifespan for {transports}",
+                        )
 
-    def test_main_invalid_transport_shows_error(self):
-        with patch.object(sys, "argv", ["duckduckgo-mcp-server"]), \
-             patch("duckduckgo_mcp_server.server.mcp"), \
-             patch("uvicorn.run"):
-            with patch.object(argparse.ArgumentParser, "parse_args") as mock_parse:
-                args = MagicMock()
-                args.transport = ["no-such-transport"]
-                args.fetch_backend = "httpx"
-                mock_parse.return_value = args
-                with self.assertRaises(SystemExit) as cm:
-                    duckduckgo_mcp_server.server.main()
-                self.assertEqual(cm.exception.code, 1)
+    def test_main_stdio_rejects_host_port(self):
+        for bad_arg in (
+            ["--host", "0.0.0.0"],
+            ["--port", "7070"],
+            ["--host", "0.0.0.0", "--port", "7070"],
+        ):
+            with self.subTest(bad_arg=bad_arg):
+                argv = ["duckduckgo-mcp-server"] + bad_arg
+                with patch.object(sys, "argv", argv), \
+                     patch("duckduckgo_mcp_server.server.mcp"):
+                    with self.assertRaises(SystemExit):
+                        duckduckgo_mcp_server.server.main()
+
+    def test_main_http_uses_default_host_port(self):
+        argv = ["duckduckgo-mcp-server", "--transport", "streamable-http"]
+        with patch.object(sys, "argv", argv), \
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
+             patch("uvicorn.run") as mock_uvicorn_run:
+            _setup_mock_mcp_for_http(mock_mcp)
+            duckduckgo_mcp_server.server.main()
+            self.assertEqual(mock_mcp.settings.host, "127.0.0.1")
+            self.assertEqual(mock_mcp.settings.port, 8000)
+            call_kwargs = mock_uvicorn_run.call_args.kwargs
+            self.assertEqual(call_kwargs["host"], "127.0.0.1")
+            self.assertEqual(call_kwargs["port"], 8000)
 
 
 class TestConfiguration(unittest.TestCase):

--- a/src/duckduckgo_mcp_server/test_server.py
+++ b/src/duckduckgo_mcp_server/test_server.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import sys
 import threading
@@ -7,6 +8,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 import unittest
 
 import httpx
+from starlette.routing import Route as StarletteRoute
 
 import duckduckgo_mcp_server.server
 
@@ -534,6 +536,24 @@ class TestWebContentFetcherAutoFallback(unittest.TestCase):
         self.assertTrue(result.startswith("Error"))
 
 
+def _setup_mock_mcp_for_http(mock_mcp):
+    mock_mcp.settings.host = "127.0.0.1"
+    mock_mcp.settings.port = 8000
+    mock_mcp.settings.sse_path = "/sse"
+    mock_mcp.settings.streamable_http_path = "/mcp"
+
+    sse_app = MagicMock()
+    sse_app.router.lifespan_context = MagicMock(name="sse_lifespan")
+    http_app = MagicMock()
+    http_app.router.lifespan_context = MagicMock(name="http_lifespan")
+
+    mock_mcp.sse_app.return_value = sse_app
+    mock_mcp.streamable_http_app.return_value = http_app
+    sse_app.routes = []
+    http_app.routes = []
+    return sse_app, http_app
+
+
 class TestMainCliArgs(unittest.TestCase):
     def test_main_parses_fetch_backend_flag(self):
         with patch.object(sys, "argv", ["duckduckgo-mcp-server", "--fetch-backend", "auto"]), \
@@ -549,6 +569,19 @@ class TestMainCliArgs(unittest.TestCase):
             mock_mcp.run.assert_called_once()
         self.assertEqual(duckduckgo_mcp_server.server.fetcher.default_backend, "httpx")
 
+    def test_main_stdio_rejects_mixed_with_http(self):
+        for bad_transports in [
+            ["stdio", "sse"],
+            ["stdio", "streamable-http"],
+            ["stdio", "sse", "streamable-http"],
+        ]:
+            with self.subTest(transports=bad_transports):
+                argv = ["duckduckgo-mcp-server", "--transport"] + bad_transports
+                with patch.object(sys, "argv", argv), \
+                     patch("duckduckgo_mcp_server.server.mcp"):
+                    with self.assertRaises(SystemExit):
+                        duckduckgo_mcp_server.server.main()
+
     def test_main_applies_host_and_port_to_settings(self):
         argv = [
             "duckduckgo-mcp-server",
@@ -557,18 +590,109 @@ class TestMainCliArgs(unittest.TestCase):
             "--port", "7070",
         ]
         with patch.object(sys, "argv", argv), \
-             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp:
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
+             patch("uvicorn.run") as mock_uvicorn_run:
+            _setup_mock_mcp_for_http(mock_mcp)
             duckduckgo_mcp_server.server.main()
             self.assertEqual(mock_mcp.settings.host, "0.0.0.0")
             self.assertEqual(mock_mcp.settings.port, 7070)
-            mock_mcp.run.assert_called_once_with(transport="streamable-http")
+            mock_uvicorn_run.assert_called_once()
+            call_kwargs = mock_uvicorn_run.call_args.kwargs
+            self.assertEqual(call_kwargs["host"], "0.0.0.0")
+            self.assertEqual(call_kwargs["port"], 7070)
 
-    def test_main_rejects_host_or_port_with_stdio(self):
-        argv = ["duckduckgo-mcp-server", "--port", "7070"]
+    def test_main_dual_transport_adds_post_sse_route(self):
+        argv = ["duckduckgo-mcp-server", "--transport", "sse", "streamable-http"]
         with patch.object(sys, "argv", argv), \
-             patch("duckduckgo_mcp_server.server.mcp"):
-            with self.assertRaises(SystemExit):
-                duckduckgo_mcp_server.server.main()
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
+             patch("uvicorn.run") as mock_uvicorn_run:
+            _setup_mock_mcp_for_http(mock_mcp)
+            async def handler(request):
+                pass
+            mcp_route = StarletteRoute("/mcp", handler, methods=["GET"])
+            mock_mcp.streamable_http_app.return_value.routes = [mcp_route]
+            duckduckgo_mcp_server.server.main()
+            app = mock_uvicorn_run.call_args[0][0]
+            post_sse_routes = [
+                r for r in app.routes
+                if isinstance(r, StarletteRoute) and r.path == "/sse" and "POST" in r.methods
+            ]
+            self.assertEqual(len(post_sse_routes), 1)
+
+    def test_main_route_dedup_prevents_duplicates(self):
+        argv = ["duckduckgo-mcp-server", "--transport", "sse", "streamable-http"]
+        async def handler(request):
+            pass
+        shared = StarletteRoute("/common", handler, methods=["GET"])
+        with patch.object(sys, "argv", argv), \
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
+             patch("uvicorn.run") as mock_uvicorn_run:
+            sse_app, http_app = _setup_mock_mcp_for_http(mock_mcp)
+            sse_app.routes = [shared]
+            http_app.routes = [shared]
+            duckduckgo_mcp_server.server.main()
+            app = mock_uvicorn_run.call_args[0][0]
+            matching = [
+                r for r in app.routes
+                if isinstance(r, StarletteRoute) and r.path == "/common" and "GET" in r.methods
+            ]
+            self.assertEqual(len(matching), 1, "Same (path, method) should be deduplicated")
+
+    def test_main_route_dedup_allows_different_methods(self):
+        argv = ["duckduckgo-mcp-server", "--transport", "sse", "streamable-http"]
+        async def handler(request):
+            pass
+        get_route = StarletteRoute("/common", handler, methods=["GET"])
+        post_route = StarletteRoute("/common", handler, methods=["POST"])
+        with patch.object(sys, "argv", argv), \
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
+             patch("uvicorn.run") as mock_uvicorn_run:
+            sse_app, http_app = _setup_mock_mcp_for_http(mock_mcp)
+            sse_app.routes = [get_route]
+            http_app.routes = [post_route]
+            duckduckgo_mcp_server.server.main()
+            app = mock_uvicorn_run.call_args[0][0]
+            matching = [
+                r for r in app.routes
+                if isinstance(r, StarletteRoute) and r.path == "/common"
+            ]
+            self.assertEqual(len(matching), 2, "Same path with different methods should both be added")
+            self.assertTrue(any("GET" in r.methods for r in matching))
+            self.assertTrue(any("POST" in r.methods for r in matching))
+
+    def test_main_lifespan_selection(self):
+        for transports, expected_lifespan_name in [
+            (["sse"], "sse_lifespan"),
+            (["streamable-http"], "http_lifespan"),
+            (["sse", "streamable-http"], "http_lifespan"),
+        ]:
+            with self.subTest(transports=transports):
+                argv = ["duckduckgo-mcp-server", "--transport"] + transports
+                with patch.object(sys, "argv", argv), \
+                     patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
+                     patch("uvicorn.run") as mock_uvicorn_run:
+                    _setup_mock_mcp_for_http(mock_mcp)
+                    duckduckgo_mcp_server.server.main()
+                    app = mock_uvicorn_run.call_args[0][0]
+                    lifespan = app.router.lifespan_context
+                    self.assertEqual(
+                        lifespan._mock_name,
+                        expected_lifespan_name,
+                        f"Wrong lifespan for {transports}",
+                    )
+
+    def test_main_invalid_transport_shows_error(self):
+        with patch.object(sys, "argv", ["duckduckgo-mcp-server"]), \
+             patch("duckduckgo_mcp_server.server.mcp"), \
+             patch("uvicorn.run"):
+            with patch.object(argparse.ArgumentParser, "parse_args") as mock_parse:
+                args = MagicMock()
+                args.transport = ["no-such-transport"]
+                args.fetch_backend = "httpx"
+                mock_parse.return_value = args
+                with self.assertRaises(SystemExit) as cm:
+                    duckduckgo_mcp_server.server.main()
+                self.assertEqual(cm.exception.code, 1)
 
 
 class TestConfiguration(unittest.TestCase):


### PR DESCRIPTION
### The problem

Browser-based MCP clients (like llama.cpp WebUI) couldn't connect to the
server when run with `--transport sse` or `--transport streamable-http`.
The FastMCP apps don't include CORS headers, so cross-origin requests from
the browser get blocked.

### What this PR does

- Allows multiple HTTP transports simultaneously
  (`--transport sse streamable-http`)
- Combines SSE and Streamable HTTP routes into a single Starlette app
  with route deduplication
- Adds CORS middleware so browser-based clients can connect
- Wraps both lifespan contexts together when dual transports are active
- Fixes `--host`/`--port` argparse defaults so validation still fires
  for `stdio + --port` misuse

### Note on llama.cpp WebUI

llama.cpp's `detectMcpTransportFromUrl()` never returns SSE — any
non-WebSocket URL gets forced to Streamable HTTP. If you point it at
`/sse` it POSTs there and gets a 405. The correct setup is:
duckduckgo-mcp-server --transport streamable-http
Then set the MCP URL to `http://localhost:8000/mcp` in the WebUI.

### Scope

- Only touched the transport handling in `main()`
- Kept all original help text exactly the same
- No new dependencies (Starlette and uvicorn already pulled in by
  `mcp[cli]`)
- `stdio` mode works exactly like before

Tested it with llama.cpp and it finally connects. Also tested plain `stdio`, `sse`, and `streamable-http` separately.