### PR TITLE
fix: update browser fingerprint to bypass DuckDuckGo bot detection

### DIFF
--- a/ddg_fix.patch
+++ b/ddg_fix.patch
@@ -1,0 +1,25 @@
+diff --git a/src/duckduckgo_mcp_server/server.py b/src/duckduckgo_mcp_server/server.py
+index 46e44aa..096b210 100644
+--- a/src/duckduckgo_mcp_server/server.py
++++ b/src/duckduckgo_mcp_server/server.py
+@@ -54,7 +54,19 @@ class RateLimiter:
+ class DuckDuckGoSearcher:
+     BASE_URL = "https://html.duckduckgo.com/html"
+     HEADERS = {
+-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
++        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
++        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
++        "Accept-Language": "en-US,en;q=0.9",
++        "Accept-Encoding": "gzip, deflate",
++        "Connection": "keep-alive",
++        "Sec-Fetch-Dest": "document",
++        "Sec-Fetch-Mode": "navigate",
++        "Sec-Fetch-Site": "none",
++        "Sec-Fetch-User": "?1",
++        "Sec-Ch-Ua": '"Not;A=Brand";v="99", "Google Chrome";v="139", "Chromium";v="139"',
++        "Sec-Ch-Ua-Mobile": "?0",
++        "Sec-Ch-Ua-Platform": '"Windows"',
++        "Upgrade-Insecure-Requests": "1",
+     }
+ 
+     def __init__(self, safe_search: SafeSearchMode = SafeSearchMode.MODERATE, default_region: str = ""):

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -54,7 +54,19 @@ class RateLimiter:
 class DuckDuckGoSearcher:
     BASE_URL = "https://html.duckduckgo.com/html"
     HEADERS = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "Sec-Ch-Ua": '"Not;A=Brand";v="99", "Google Chrome";v="139", "Chromium";v="139"',
+        "Sec-Ch-Ua-Mobile": "?0",
+        "Sec-Ch-Ua-Platform": '"Windows"',
+        "Upgrade-Insecure-Requests": "1",
     }
 
     def __init__(self, safe_search: SafeSearchMode = SafeSearchMode.MODERATE, default_region: str = ""):


### PR DESCRIPTION
- Upgrade User-Agent from Chrome 91 (2021) to Chrome 139 (2025)
- Add full browser headers: Accept, Accept-Language, Sec-Fetch, Sec-Ch-Ua

DuckDuckGo was blocking the old fingerprint with a bot challenge page, resulting in zero search results. New headers return actual results.
This is more of a temporary fix . Browser fingerprints will need periodic updates as DuckDuckGo evolves their bot detection. 
A  long-term solution might be using an official search API or a different approach altogether.