### PR TITLE
fix(search): curl backend + HTTP 202 handling to restore search (#46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Two MCP tools are exposed: `search` and `fetch_content`.
 Environment variables read at startup (not per-request):
 - `DDG_SAFE_SEARCH`: `STRICT` | `MODERATE` (default) | `OFF`
 - `DDG_REGION`: Region code like `us-en`, `cn-zh`, `jp-ja`, `wt-wt`
+- `DDG_SEARCH_BACKEND`: `auto` (default) | `httpx` | `curl` — HTTP backend for the search tool. `auto` falls back to curl_cffi Chrome TLS impersonation when DuckDuckGo returns a fingerprint block (HTTP 202/403); `curl`/fallback need the `[browser]` extra. Also settable via `--search-backend`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ When running with `sse` or `streamable-http`, override the default bind address 
 uvx duckduckgo-mcp-server --transport streamable-http --host 0.0.0.0 --port 7070
 ```
 
-### Fetch Backend (bypassing bot detection)
+### Backends (bypassing bot detection)
 
-Some sites block the default `httpx` client because of its distinctive TLS fingerprint, regardless of User-Agent — Cloudflare Bot Management and similar filters key on the JA3/TLS handshake, not on headers. An opt-in backend, `curl` (implemented via `curl_cffi`), impersonates a real Chrome browser's TLS handshake and passes through those checks.
+Some sites — and, as of recently, DuckDuckGo's own search endpoint (`html.duckduckgo.com`) — block the default `httpx` client because of its distinctive TLS fingerprint, regardless of User-Agent. Cloudflare Bot Management and similar filters key on the JA3/TLS handshake, not on headers, so `html.duckduckgo.com` may answer `httpx` with an empty **HTTP 202** page (silently yielding "no results"). An opt-in backend, `curl` (implemented via `curl_cffi`), impersonates a real Chrome browser's TLS handshake and passes through those checks.
+
+Both the `search` tool and the `fetch_content` tool support these backends.
 
 **Installation:**
 
@@ -146,9 +148,24 @@ uv pip install "duckduckgo-mcp-server[browser]"
 
 2. **Per-call override** via the `backend` argument on the `fetch_content` tool (overrides the CLI default for that single call). The tool exposes `backend` in its input schema, so an MCP client can choose `"httpx"`, `"curl"`, or `"auto"` on a fetch-by-fetch basis.
 
-The `search` tool always uses `httpx` — DuckDuckGo's search endpoint doesn't require impersonation.
+For `fetch_content`, the default stays `httpx` so users who don't need the impersonation don't pay for the extra dependency.
 
-The default stays `httpx` so users who don't need the impersonation don't pay for the extra dependency.
+#### Search backend
+
+Because DuckDuckGo's search endpoint now fingerprint-blocks plain `httpx`, the `search` tool defaults to **`auto`**: it tries `httpx` first and falls back to `curl` when it detects a block (HTTP 202/403). The fallback only works if the `[browser]` extra is installed; otherwise search returns a message telling you to install it.
+
+Configure the search backend with the `--search-backend` CLI flag or the `DDG_SEARCH_BACKEND` environment variable (`auto` (default) / `httpx` / `curl`):
+
+```bash
+# Recommended: install the browser extra so the auto fallback can impersonate Chrome
+uvx --with "duckduckgo-mcp-server[browser]" duckduckgo-mcp-server
+
+# Force curl for every search
+uvx --with "duckduckgo-mcp-server[browser]" duckduckgo-mcp-server --search-backend curl
+
+# Opt out of the fallback (legacy behavior — may return no results while blocked)
+uvx duckduckgo-mcp-server --search-backend httpx
+```
 
 ### Development
 

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -73,6 +73,15 @@ def _is_search_block(status: int, html: str) -> bool:
     return False
 
 
+def _curl_cffi_available() -> bool:
+    """Return True if the optional curl_cffi (Chrome TLS impersonation) is installed."""
+    try:
+        import curl_cffi  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 class DuckDuckGoSearcher:
     BASE_URL = "https://html.duckduckgo.com/html"
     HEADERS = {
@@ -121,14 +130,22 @@ class DuckDuckGoSearcher:
     def format_results_for_llm(self, results: List[SearchResult]) -> str:
         """Format results in a natural language style that's easier for LLMs to process"""
         if not results:
-            return (
+            message = (
                 "No results were found for your search query. This could be due to "
                 "DuckDuckGo's bot detection or the query returned no matches. Please try "
-                "rephrasing your search or try again in a few minutes. If this persists, "
-                "DuckDuckGo may be blocking this server's TLS fingerprint; installing the "
-                "optional browser backend (pip install 'duckduckgo-mcp-server[browser]') "
-                "enables Chrome TLS impersonation, which typically resolves it."
+                "rephrasing your search or try again in a few minutes."
             )
+            # Only suggest the browser backend when it isn't already installed —
+            # if curl_cffi is present the impersonation fallback already ran, so
+            # pointing the user at an install they've done would just mislead.
+            if not _curl_cffi_available():
+                message += (
+                    " If this persists, DuckDuckGo may be blocking this server's TLS "
+                    "fingerprint; installing the optional browser backend "
+                    "(pip install 'duckduckgo-mcp-server[browser]') enables Chrome TLS "
+                    "impersonation, which typically resolves it."
+                )
+            return message
 
         output = []
         output.append(f"Found {len(results)} search results:\n")
@@ -256,6 +273,15 @@ class DuckDuckGoSearcher:
                 await ctx.info("DuckDuckGo returned HTTP 403 to httpx; retrying with curl backend")
                 return await self._request_curl(data)
             raise
+        except httpx.ConnectError as e:
+            # A rejected/reset TLS handshake surfaces as a ConnectError (not an
+            # HTTPStatusError), so give curl's impersonated handshake a shot before
+            # giving up. curl uses a separate network stack, so on a genuine outage
+            # it fails fast rather than masking the real error.
+            await ctx.info(
+                f"httpx connection error ({type(e).__name__}); retrying with curl backend"
+            )
+            return await self._request_curl(data)
 
         if _is_search_block(status, html):
             await ctx.info(

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -51,28 +51,84 @@ class RateLimiter:
         self.requests.append(now)
 
 
+# Backends shared by both search and fetch_content. "auto" tries httpx first and
+# falls back to curl (curl_cffi Chrome TLS impersonation) when the response looks
+# like a fingerprint-based block.
+SUPPORTED_FETCH_BACKENDS = ("httpx", "curl", "auto")
+
+
+def _is_search_block(status: int, html: str) -> bool:
+    """Detect a fingerprint-based block on the DuckDuckGo HTML search endpoint.
+
+    html.duckduckgo.com now serves an HTTP 202 with an empty results page to
+    clients whose TLS fingerprint it doesn't like (see issue #46). Because 202 is
+    a 2xx status, ``raise_for_status()`` never fires and the empty page silently
+    parses to zero results. A 403 is the other classic block signal, and a truly
+    empty 200 body is treated the same way.
+    """
+    if status in (202, 403):
+        return True
+    if status == 200 and not (html or "").strip():
+        return True
+    return False
+
+
 class DuckDuckGoSearcher:
     BASE_URL = "https://html.duckduckgo.com/html"
     HEADERS = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "Sec-Ch-Ua": '"Not;A=Brand";v="99", "Google Chrome";v="139", "Chromium";v="139"',
+        "Sec-Ch-Ua-Mobile": "?0",
+        "Sec-Ch-Ua-Platform": '"Windows"',
+        "Upgrade-Insecure-Requests": "1",
     }
 
-    def __init__(self, safe_search: SafeSearchMode = SafeSearchMode.MODERATE, default_region: str = ""):
+    def __init__(
+        self,
+        safe_search: SafeSearchMode = SafeSearchMode.MODERATE,
+        default_region: str = "",
+        backend: str = "auto",
+    ):
         """
         Initialize DuckDuckGo searcher
 
         Args:
             safe_search: SafeSearch filtering mode (STRICT/MODERATE/OFF) - fixed at startup
             default_region: Default region code (e.g., 'us-en', 'cn-zh', 'wt-wt' for no region)
+            backend: HTTP client backend for the search request. One of "httpx",
+                "curl", or "auto" (default). "auto" tries httpx first and falls back
+                to curl_cffi Chrome TLS impersonation when DuckDuckGo returns a
+                fingerprint-based block (HTTP 202/403). "curl" and the auto fallback
+                require the optional [browser] extra.
         """
+        if backend not in SUPPORTED_FETCH_BACKENDS:
+            raise ValueError(
+                f"Unknown search backend '{backend}'. Supported: {SUPPORTED_FETCH_BACKENDS}"
+            )
         self.rate_limiter = RateLimiter()
         self.safe_search = safe_search
         self.default_region = default_region
+        self.backend = backend
 
     def format_results_for_llm(self, results: List[SearchResult]) -> str:
         """Format results in a natural language style that's easier for LLMs to process"""
         if not results:
-            return "No results were found for your search query. This could be due to DuckDuckGo's bot detection or the query returned no matches. Please try rephrasing your search or try again in a few minutes."
+            return (
+                "No results were found for your search query. This could be due to "
+                "DuckDuckGo's bot detection or the query returned no matches. Please try "
+                "rephrasing your search or try again in a few minutes. If this persists, "
+                "DuckDuckGo may be blocking this server's TLS fingerprint; installing the "
+                "optional browser backend (pip install 'duckduckgo-mcp-server[browser]') "
+                "enables Chrome TLS impersonation, which typically resolves it."
+            )
 
         output = []
         output.append(f"Found {len(results)} search results:\n")
@@ -112,16 +168,17 @@ class DuckDuckGoSearcher:
                 "kp": self.safe_search.value,  # SafeSearch mode (fixed)
             }
 
-            await ctx.info(f"Searching DuckDuckGo for: {query} (SafeSearch: {self.safe_search.name}, Region: {effective_region or 'default'})")
+            await ctx.info(f"Searching DuckDuckGo for: {query} (SafeSearch: {self.safe_search.name}, Region: {effective_region or 'default'}, backend={self.backend})")
 
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    self.BASE_URL, data=data, headers=self.HEADERS, timeout=30.0
-                )
-                response.raise_for_status()
+            try:
+                html = await self._request(data, ctx)
+            except RuntimeError as e:
+                # curl backend requested/needed but curl_cffi isn't installed.
+                await ctx.error(str(e))
+                return []
 
             # Parse HTML response
-            soup = BeautifulSoup(response.text, "html.parser")
+            soup = BeautifulSoup(html, "html.parser")
             if not soup:
                 await ctx.error("Failed to parse HTML response")
                 return []
@@ -176,8 +233,67 @@ class DuckDuckGoSearcher:
             traceback.print_exc(file=sys.stderr)
             return []
 
+    async def _request(self, data: dict, ctx: Context) -> str:
+        """Perform the search POST using the configured backend, returning raw HTML.
 
-SUPPORTED_FETCH_BACKENDS = ("httpx", "curl", "auto")
+        Under "auto", tries httpx first and transparently retries with curl when
+        DuckDuckGo returns a fingerprint-based block (HTTP 202/403), which httpx's
+        TLS handshake now trips (issue #46).
+        """
+        if self.backend == "curl":
+            return await self._request_curl(data)
+
+        if self.backend == "httpx":
+            _status, html = await self._request_httpx(data)
+            return html
+
+        # auto: httpx first, fall back to curl on a block signal.
+        try:
+            status, html = await self._request_httpx(data)
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code if e.response is not None else None
+            if status == 403:
+                await ctx.info("DuckDuckGo returned HTTP 403 to httpx; retrying with curl backend")
+                return await self._request_curl(data)
+            raise
+
+        if _is_search_block(status, html):
+            await ctx.info(
+                f"DuckDuckGo returned a block signal (HTTP {status}) to httpx; retrying with curl backend"
+            )
+            return await self._request_curl(data)
+
+        return html
+
+    async def _request_httpx(self, data: dict) -> tuple[int, str]:
+        """POST the search form via httpx. Returns (status_code, body).
+
+        Note: a fingerprint-blocked response is HTTP 202 (a 2xx), so
+        ``raise_for_status()`` does not fire — the caller inspects the status.
+        """
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self.BASE_URL, data=data, headers=self.HEADERS, timeout=30.0
+            )
+            response.raise_for_status()
+            return response.status_code, response.text
+
+    async def _request_curl(self, data: dict) -> str:
+        """POST the search form via curl_cffi with Chrome 131 TLS impersonation."""
+        try:
+            from curl_cffi.requests import AsyncSession
+        except ImportError as e:
+            raise RuntimeError(
+                "The 'curl' search backend requires curl_cffi, which is not installed. "
+                "Install the optional extra: pip install 'duckduckgo-mcp-server[browser]'"
+            ) from e
+        # Let curl_cffi supply the impersonated browser headers for a consistent
+        # Chrome fingerprint; we only send the search form fields.
+        async with AsyncSession(impersonate="chrome131") as client:
+            response = await client.post(self.BASE_URL, data=data, timeout=30.0)
+            response.raise_for_status()
+            return response.text
+
 
 # Cloudflare / bot-filter challenge signals that appear in response bodies even
 # when the HTTP status is 200. If we see these on an httpx fetch under `auto`,
@@ -368,6 +484,7 @@ mcp = FastMCP("ddg-search")
 # Read configuration from environment variables
 SAFE_SEARCH_MODE = os.getenv("DDG_SAFE_SEARCH", "MODERATE").upper()
 REGION_CODE = os.getenv("DDG_REGION", "")
+SEARCH_BACKEND = os.getenv("DDG_SEARCH_BACKEND", "auto").lower()
 
 # Validate and set SafeSearch mode
 try:
@@ -376,12 +493,18 @@ except KeyError:
     print(f"Warning: Invalid DDG_SAFE_SEARCH value '{SAFE_SEARCH_MODE}', using MODERATE", file=sys.stderr)
     safe_search = SafeSearchMode.MODERATE
 
-searcher = DuckDuckGoSearcher(safe_search=safe_search, default_region=REGION_CODE)
+# Validate search backend
+if SEARCH_BACKEND not in SUPPORTED_FETCH_BACKENDS:
+    print(f"Warning: Invalid DDG_SEARCH_BACKEND value '{SEARCH_BACKEND}', using auto", file=sys.stderr)
+    SEARCH_BACKEND = "auto"
+
+searcher = DuckDuckGoSearcher(safe_search=safe_search, default_region=REGION_CODE, backend=SEARCH_BACKEND)
 fetcher = WebContentFetcher()
 
 print(f"DuckDuckGo MCP Server initialized:", file=sys.stderr)
 print(f"  SafeSearch: {safe_search.name} (kp={safe_search.value})", file=sys.stderr)
 print(f"  Default Region: {REGION_CODE or 'none'}", file=sys.stderr)
+print(f"  Search backend: {searcher.backend}", file=sys.stderr)
 
 
 @mcp.tool()
@@ -427,7 +550,7 @@ async def fetch_content(
 
 
 def main():
-    global fetcher
+    global fetcher, searcher
     from starlette.applications import Starlette
     from starlette.middleware.cors import CORSMiddleware
     from starlette.routing import BaseRoute, Route
@@ -455,6 +578,18 @@ def main():
         ),
     )
     parser.add_argument(
+        "--search-backend",
+        choices=list(SUPPORTED_FETCH_BACKENDS),
+        default=None,
+        help=(
+            "HTTP backend for the search tool. Defaults to 'auto' (or the "
+            "DDG_SEARCH_BACKEND env var). 'auto' tries httpx first and falls back to "
+            "curl (curl_cffi Chrome TLS impersonation) when DuckDuckGo returns a "
+            "fingerprint-based block (HTTP 202/403). 'curl' and the auto fallback "
+            "require the [browser] extra."
+        ),
+    )
+    parser.add_argument(
         "--host",
         default=None,
         help="Bind address for sse / streamable-http transports (default: 127.0.0.1).",
@@ -478,6 +613,14 @@ def main():
     # Reconfigure the module-level fetcher with the chosen backend.
     fetcher = WebContentFetcher(backend=args.fetch_backend)
     print(f"  Fetch backend: {fetcher.default_backend}", file=sys.stderr)
+
+    # Reconfigure the module-level searcher if a backend was given on the CLI
+    # (otherwise it keeps the env-derived DDG_SEARCH_BACKEND default).
+    if args.search_backend is not None:
+        searcher = DuckDuckGoSearcher(
+            safe_search=safe_search, default_region=REGION_CODE, backend=args.search_backend
+        )
+        print(f"  Search backend: {searcher.backend}", file=sys.stderr)
 
     if transports == {"stdio"}:
         mcp.run(transport="stdio")

--- a/src/duckduckgo_mcp_server/test_server.py
+++ b/src/duckduckgo_mcp_server/test_server.py
@@ -323,6 +323,42 @@ class TestDuckDuckGoSearcherBackend(unittest.TestCase):
         self.assertEqual(called["curl"], 0)
         self.assertEqual(len(results), 1)
 
+    def test_auto_falls_back_to_curl_on_connect_error(self):
+        """A rejected TLS handshake (httpx.ConnectError) should retry with curl."""
+        searcher = DuckDuckGoSearcher(backend="auto")
+        html = _make_ddg_html([
+            {"title": "Rescued", "href": "https://rescued.com", "snippet": "via curl"},
+        ])
+        called = {"curl": 0}
+
+        async def fake_httpx(data):
+            raise httpx.ConnectError("TLS handshake rejected")
+
+        async def fake_curl(data):
+            called["curl"] += 1
+            return html
+
+        with patch.object(searcher, "_request_httpx", side_effect=fake_httpx), \
+             patch.object(searcher, "_request_curl", side_effect=fake_curl):
+            results = asyncio.run(searcher.search("q", DummyCtx()))
+
+        self.assertEqual(called["curl"], 1)
+        self.assertEqual(len(results), 1)
+
+    def test_empty_results_message_omits_hint_when_curl_installed(self):
+        """When curl_cffi is available the 'install [browser]' hint is dropped."""
+        searcher = DuckDuckGoSearcher()
+        with patch("duckduckgo_mcp_server.server._curl_cffi_available", return_value=True):
+            message = searcher.format_results_for_llm([])
+        self.assertIn("No results were found", message)
+        self.assertNotIn("pip install", message)
+
+    def test_empty_results_message_includes_hint_when_curl_missing(self):
+        searcher = DuckDuckGoSearcher()
+        with patch("duckduckgo_mcp_server.server._curl_cffi_available", return_value=False):
+            message = searcher.format_results_for_llm([])
+        self.assertIn("pip install 'duckduckgo-mcp-server[browser]'", message)
+
     def test_httpx_backend_does_not_fall_back_on_202(self):
         """Explicit httpx backend keeps legacy behavior: 202 → 0 results, no curl."""
         searcher = DuckDuckGoSearcher(backend="httpx")

--- a/src/duckduckgo_mcp_server/test_server.py
+++ b/src/duckduckgo_mcp_server/test_server.py
@@ -19,6 +19,7 @@ from duckduckgo_mcp_server.server import (
     SearchResult,
     SUPPORTED_FETCH_BACKENDS,
     WebContentFetcher,
+    _is_search_block,
 )
 
 try:
@@ -233,6 +234,119 @@ class TestDuckDuckGoSearcherParsing(unittest.TestCase):
     def test_search_returns_empty_on_no_results(self):
         html = "<html><body><p>No results</p></body></html>"
         results = self._run_search(html)
+        self.assertEqual(results, [])
+
+
+class TestDuckDuckGoSearcherBackend(unittest.TestCase):
+    def test_is_search_block_truth_table(self):
+        # 202 (fingerprint block) and 403 are block signals regardless of body.
+        self.assertTrue(_is_search_block(202, "<html>14kb block page</html>"))
+        self.assertTrue(_is_search_block(403, "forbidden"))
+        # A truly empty 200 body is a block; a 200 with any content is not.
+        self.assertTrue(_is_search_block(200, "   "))
+        self.assertFalse(_is_search_block(200, "<html>real results</html>"))
+        # Non-2xx errors are handled via raise_for_status, not this helper.
+        self.assertFalse(_is_search_block(500, ""))
+
+    def test_default_backend_is_auto(self):
+        self.assertEqual(DuckDuckGoSearcher().backend, "auto")
+
+    def test_init_rejects_unknown_backend(self):
+        with self.assertRaises(ValueError):
+            DuckDuckGoSearcher(backend="bogus")
+
+    def test_auto_falls_back_to_curl_on_202(self):
+        """A 202 fingerprint-block on httpx must transparently retry with curl."""
+        searcher = DuckDuckGoSearcher(backend="auto")
+        html = _make_ddg_html([
+            {"title": "Rescued", "href": "https://rescued.com", "snippet": "via curl"},
+        ])
+        called = {"curl": 0}
+
+        async def fake_httpx(data):
+            return 202, "<html><body>empty block page</body></html>"
+
+        async def fake_curl(data):
+            called["curl"] += 1
+            return html
+
+        with patch.object(searcher, "_request_httpx", side_effect=fake_httpx), \
+             patch.object(searcher, "_request_curl", side_effect=fake_curl):
+            results = asyncio.run(searcher.search("q", DummyCtx()))
+
+        self.assertEqual(called["curl"], 1)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].title, "Rescued")
+
+    def test_auto_falls_back_to_curl_on_403(self):
+        searcher = DuckDuckGoSearcher(backend="auto")
+        html = _make_ddg_html([
+            {"title": "Rescued", "href": "https://rescued.com", "snippet": "via curl"},
+        ])
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        err = httpx.HTTPStatusError("forbidden", request=MagicMock(), response=mock_resp)
+        called = {"curl": 0}
+
+        async def fake_httpx(data):
+            raise err
+
+        async def fake_curl(data):
+            called["curl"] += 1
+            return html
+
+        with patch.object(searcher, "_request_httpx", side_effect=fake_httpx), \
+             patch.object(searcher, "_request_curl", side_effect=fake_curl):
+            results = asyncio.run(searcher.search("q", DummyCtx()))
+
+        self.assertEqual(called["curl"], 1)
+        self.assertEqual(len(results), 1)
+
+    def test_auto_does_not_fall_back_on_normal_results(self):
+        searcher = DuckDuckGoSearcher(backend="auto")
+        html = _make_ddg_html([
+            {"title": "Normal", "href": "https://normal.com", "snippet": "ok"},
+        ])
+        called = {"curl": 0}
+
+        async def fake_httpx(data):
+            return 200, html
+
+        async def fake_curl(data):
+            called["curl"] += 1
+            return "<html></html>"
+
+        with patch.object(searcher, "_request_httpx", side_effect=fake_httpx), \
+             patch.object(searcher, "_request_curl", side_effect=fake_curl):
+            results = asyncio.run(searcher.search("q", DummyCtx()))
+
+        self.assertEqual(called["curl"], 0)
+        self.assertEqual(len(results), 1)
+
+    def test_httpx_backend_does_not_fall_back_on_202(self):
+        """Explicit httpx backend keeps legacy behavior: 202 → 0 results, no curl."""
+        searcher = DuckDuckGoSearcher(backend="httpx")
+        called = {"curl": 0}
+
+        async def fake_httpx(data):
+            return 202, "<html><body>empty block page</body></html>"
+
+        async def fake_curl(data):
+            called["curl"] += 1
+            return "should not be called"
+
+        with patch.object(searcher, "_request_httpx", side_effect=fake_httpx), \
+             patch.object(searcher, "_request_curl", side_effect=fake_curl):
+            results = asyncio.run(searcher.search("q", DummyCtx()))
+
+        self.assertEqual(called["curl"], 0)
+        self.assertEqual(results, [])
+
+    def test_curl_backend_missing_dependency_returns_empty(self):
+        """curl backend with curl_cffi absent → empty results (hint logged), no crash."""
+        searcher = DuckDuckGoSearcher(backend="curl")
+        with patch.dict(sys.modules, {"curl_cffi": None, "curl_cffi.requests": None}):
+            results = asyncio.run(searcher.search("q", DummyCtx()))
         self.assertEqual(results, [])
 
 
@@ -568,6 +682,13 @@ class TestMainCliArgs(unittest.TestCase):
             duckduckgo_mcp_server.server.main()
             mock_mcp.run.assert_called_once()
         self.assertEqual(duckduckgo_mcp_server.server.fetcher.default_backend, "httpx")
+
+    def test_main_parses_search_backend_flag(self):
+        with patch.object(sys, "argv", ["duckduckgo-mcp-server", "--search-backend", "curl"]), \
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp:
+            duckduckgo_mcp_server.server.main()
+            mock_mcp.run.assert_called_once()
+        self.assertEqual(duckduckgo_mcp_server.server.searcher.backend, "curl")
 
     def test_main_stdio_rejects_mixed_with_http(self):
         for bad_transports in [


### PR DESCRIPTION
## Problem

`html.duckduckgo.com` now blocks the default `httpx` client by TLS fingerprint and answers with an empty **HTTP 202** page. Because 202 is a 2xx status, `raise_for_status()` never fires, the empty page parses to zero `.result` elements, and `search` silently returns "No results were found" for every query (#46).

## Fix

- Give `DuckDuckGoSearcher` the same backend abstraction that `WebContentFetcher` already has — `httpx` / `curl` / `auto` — defaulting to **`auto`**: try `httpx`, and on a block signal fall back to `curl_cffi` Chrome-131 TLS impersonation.
- Add `_is_search_block()`: treat **HTTP 202/403** (and a truly empty 200 body) as a block signal that triggers the curl fallback.
- Fold in the Chrome-139 User-Agent + browser headers from #49 (headers alone don't defeat TLS fingerprinting, but they're harmless and match a real browser). The stray `ddg_fix.patch` from #49 is **not** included.
- New `--search-backend` flag and `DDG_SEARCH_BACKEND` env var.
- The empty-results message now hints to install the `[browser]` extra.

The `curl`/`auto` fallback requires the optional `[browser]` extra (`curl_cffi`); without it, search degrades gracefully with a clear message.

## Verification

- Full test suite passes (with and without the `[browser]` extra); new tests cover the block truth-table, curl fallback on 202/403, no-fallback on normal results, legacy `httpx`-only mode, and the CLI flag.
- Manually confirmed real DDG searches return results via the `httpx`, `auto`, and `curl` paths.

Supersedes #49. Closes #46.
