### PR TITLE
fix(security): block SSRF to private/internal targets in fetch_content (#48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Two MCP tools are exposed: `search` and `fetch_content`.
 Environment variables read at startup (not per-request):
 - `DDG_SAFE_SEARCH`: `STRICT` | `MODERATE` (default) | `OFF`
 - `DDG_REGION`: Region code like `us-en`, `cn-zh`, `jp-ja`, `wt-wt`
+- `DDG_ALLOW_PRIVATE_URLS`: `1`/`true` to let `fetch_content` reach loopback/private/link-local/metadata addresses (default off — SSRF guard). Also settable via `--allow-private-urls`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ Fetches and parses content from a webpage.
 **Returns:**
 Cleaned and formatted text content from the webpage.
 
+> **SSRF protection:** By default `fetch_content` refuses URLs that resolve to
+> loopback, private (RFC1918), link-local (including the `169.254.169.254` cloud
+> metadata endpoint), reserved, multicast, or unspecified addresses, and it
+> re-validates every redirect hop. Only `http`/`https` URLs are allowed. For
+> trusted local deployments that need to fetch internal hosts, disable the guard
+> with `DDG_ALLOW_PRIVATE_URLS=1` or `--allow-private-urls`. See
+> [SECURITY.md](SECURITY.md) for details.
+
 ## Features in Detail
 
 ### Rate Limiting

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in `duckduckgo-mcp-server`, please report
+it **privately** so it can be fixed before public disclosure:
+
+- Use GitHub's [private vulnerability reporting](https://github.com/nickclyde/duckduckgo-mcp-server/security/advisories/new)
+  (**Security → Report a vulnerability**), or
+- Email the maintainer at **nick@clyde.tech** with details and, ideally, a
+  minimal reproduction.
+
+Please do not open a public issue for undisclosed vulnerabilities.
+
+We aim to acknowledge reports within a few days and to ship a fix or mitigation
+as promptly as the severity warrants.
+
+## Supported Versions
+
+Security fixes are applied to the latest released version on
+[PyPI](https://pypi.org/project/duckduckgo-mcp-server/). Please upgrade before
+reporting to confirm the issue still reproduces.
+
+## Security Model & Hardening Notes
+
+This server fetches arbitrary web content on behalf of an MCP client, which
+carries inherent risk. Operators should be aware of the following:
+
+### Server-Side Request Forgery (SSRF)
+
+The `fetch_content` tool takes a caller-supplied URL. By default the server
+**refuses** requests whose host resolves to a non-public address — loopback
+(`127.0.0.0/8`, `::1`), private/RFC1918 ranges, link-local (including the
+`169.254.169.254` cloud metadata endpoint), reserved, multicast, and unspecified
+addresses. Only `http` and `https` URLs are allowed, and **every redirect hop is
+re-validated** so a public URL cannot bounce a request into the internal network.
+
+For trusted local deployments that intentionally need to fetch internal hosts,
+this guard can be disabled with either:
+
+- the environment variable `DDG_ALLOW_PRIVATE_URLS=1`, or
+- the CLI flag `--allow-private-urls`.
+
+Leave the guard enabled if the MCP client is driven by untrusted input (e.g. an
+LLM acting on web content).
+
+> Note: validation resolves the host and then the HTTP client resolves it again
+> to connect, leaving a small DNS-rebinding (TOCTOU) window. Default-deny plus
+> per-hop validation blocks the practical SSRF vectors; do not expose this server
+> to fully untrusted callers on a network where that residual risk matters.
+
+### Untrusted Content
+
+Search results and fetched page text come from external websites and are
+**untrusted input**. Do not treat instructions embedded in that content as
+commands (prompt injection). The tool descriptions note this explicitly.

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta
 import time
 import re
 import os
+import socket
+import ipaddress
 from enum import Enum
 
 
@@ -197,8 +199,74 @@ def _is_cloudflare_challenge_body(html: str) -> bool:
     return any(sig in sample for sig in _CLOUDFLARE_BODY_SIGNALS)
 
 
+# Maximum number of redirects fetch_content will follow. Each hop is re-validated
+# against the SSRF guard, so a public URL can't bounce us into the private network.
+_MAX_REDIRECTS = 5
+
+# HTTP status codes that carry a Location header we should follow.
+_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+
+
+class BlockedURLError(Exception):
+    """Raised when a fetch target is not an allowed public http(s) destination."""
+
+
+async def _validate_public_url(url: str) -> None:
+    """Reject non-public fetch targets (SSRF guard).
+
+    Enforces http/https and resolves the host, rejecting any URL that maps to a
+    loopback, private (RFC1918), link-local (incl. the 169.254.169.254 cloud
+    metadata endpoint), reserved, multicast, or unspecified address. Called on the
+    initial URL and on every redirect hop.
+
+    Note: this resolves the host and then lets the HTTP client resolve it again to
+    connect, so a determined attacker controlling DNS could rebind between the two
+    lookups (TOCTOU). Pinning the connection to the validated IP is out of scope;
+    default-deny plus per-hop validation blocks the practical SSRF vectors.
+    """
+    parsed = urllib.parse.urlsplit(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise BlockedURLError(
+            f"unsupported URL scheme '{parsed.scheme}://' (only http and https are allowed)"
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise BlockedURLError("URL has no host")
+
+    lowered = host.lower()
+    if lowered == "localhost" or lowered.endswith(".localhost"):
+        raise BlockedURLError(f"refusing to fetch loopback host '{host}'")
+
+    port = parsed.port or (443 if scheme == "https" else 80)
+    try:
+        infos = await asyncio.to_thread(
+            socket.getaddrinfo, host, port, 0, socket.SOCK_STREAM
+        )
+    except socket.gaierror as e:
+        raise BlockedURLError(f"could not resolve host '{host}': {e}") from e
+
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        # Unwrap IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) before classifying.
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise BlockedURLError(
+                f"refusing to fetch '{host}' — it resolves to non-public address {ip}"
+            )
+
+
 class WebContentFetcher:
-    def __init__(self, backend: str = "httpx"):
+    def __init__(self, backend: str = "httpx", allow_private_urls: bool = False):
         """
         Initialize the web content fetcher.
 
@@ -211,30 +279,54 @@ class WebContentFetcher:
                 `pip install 'duckduckgo-mcp-server[browser]'`.
               - "auto": try httpx first; if the response looks like a 403 or a
                 Cloudflare challenge, transparently retry with curl.
+            allow_private_urls: When False (default), fetch_content refuses URLs that
+                resolve to loopback/private/link-local/metadata addresses (SSRF guard).
+                Set True only for trusted local deployments that intentionally fetch
+                internal hosts.
         """
         if backend not in SUPPORTED_FETCH_BACKENDS:
             raise ValueError(
                 f"Unknown fetch backend '{backend}'. Supported: {SUPPORTED_FETCH_BACKENDS}"
             )
         self.default_backend = backend
+        self.allow_private_urls = allow_private_urls
         self.rate_limiter = RateLimiter(requests_per_minute=20)
 
+    async def _guard_url(self, url: str) -> None:
+        """Apply the SSRF guard unless private URLs are explicitly allowed."""
+        if not self.allow_private_urls:
+            await _validate_public_url(url)
+
     async def _fetch_httpx(self, url: str) -> str:
-        """Fetch URL via httpx. Raises httpx.HTTPStatusError on non-2xx."""
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                url,
-                headers={
-                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
-                },
-                follow_redirects=True,
-                timeout=30.0,
-            )
-            response.raise_for_status()
-            return response.text
+        """Fetch URL via httpx, validating the target and every redirect hop.
+
+        Redirects are followed manually (not via follow_redirects=True) so the SSRF
+        guard runs on each hop. Raises httpx.HTTPStatusError on non-2xx.
+        """
+        async with httpx.AsyncClient(follow_redirects=False) as client:
+            current = url
+            for _ in range(_MAX_REDIRECTS + 1):
+                await self._guard_url(current)
+                response = await client.get(
+                    current,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+                    },
+                    timeout=30.0,
+                )
+                location = response.headers.get("location")
+                if response.status_code in _REDIRECT_STATUSES and location:
+                    current = str(httpx.URL(current).join(location))
+                    continue
+                response.raise_for_status()
+                return response.text
+            raise httpx.HTTPError(f"too many redirects (>{_MAX_REDIRECTS})")
 
     async def _fetch_curl(self, url: str) -> str:
-        """Fetch URL via curl_cffi with Chrome 131 TLS impersonation."""
+        """Fetch URL via curl_cffi with Chrome 131 TLS impersonation.
+
+        Redirects are followed manually so the SSRF guard runs on each hop.
+        """
         try:
             from curl_cffi.requests import AsyncSession
         except ImportError as e:
@@ -243,9 +335,17 @@ class WebContentFetcher:
                 "Install the optional extra: pip install 'duckduckgo-mcp-server[browser]'"
             ) from e
         async with AsyncSession(impersonate="chrome131") as client:
-            response = await client.get(url, allow_redirects=True, timeout=30.0)
-            response.raise_for_status()
-            return response.text
+            current = url
+            for _ in range(_MAX_REDIRECTS + 1):
+                await self._guard_url(current)
+                response = await client.get(current, allow_redirects=False, timeout=30.0)
+                location = response.headers.get("location")
+                if response.status_code in _REDIRECT_STATUSES and location:
+                    current = urllib.parse.urljoin(current, location)
+                    continue
+                response.raise_for_status()
+                return response.text
+            raise httpx.HTTPError(f"too many redirects (>{_MAX_REDIRECTS})")
 
     async def _fetch_auto(self, url: str, ctx: Context) -> str:
         """
@@ -340,6 +440,13 @@ class WebContentFetcher:
             )
             return text
 
+        except BlockedURLError as e:
+            await ctx.error(f"Blocked fetch for {url}: {e}")
+            return (
+                f"Error: Refusing to fetch {url} ({e}). This server blocks requests to "
+                "private/internal addresses to prevent SSRF. If this is a trusted local "
+                "deployment, set DDG_ALLOW_PRIVATE_URLS=1 (or pass --allow-private-urls)."
+            )
         except httpx.TimeoutException:
             await ctx.error(f"Request timed out for URL: {url}")
             return "Error: The request timed out while trying to fetch the webpage."
@@ -365,9 +472,15 @@ class WebContentFetcher:
 # Initialize FastMCP server
 mcp = FastMCP("ddg-search")
 
+def _env_flag(name: str) -> bool:
+    """True when the named env var is set to a truthy string (1/true/yes/on)."""
+    return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
 # Read configuration from environment variables
 SAFE_SEARCH_MODE = os.getenv("DDG_SAFE_SEARCH", "MODERATE").upper()
 REGION_CODE = os.getenv("DDG_REGION", "")
+ALLOW_PRIVATE_URLS = _env_flag("DDG_ALLOW_PRIVATE_URLS")
 
 # Validate and set SafeSearch mode
 try:
@@ -377,7 +490,7 @@ except KeyError:
     safe_search = SafeSearchMode.MODERATE
 
 searcher = DuckDuckGoSearcher(safe_search=safe_search, default_region=REGION_CODE)
-fetcher = WebContentFetcher()
+fetcher = WebContentFetcher(allow_private_urls=ALLOW_PRIVATE_URLS)
 
 print(f"DuckDuckGo MCP Server initialized:", file=sys.stderr)
 print(f"  SafeSearch: {safe_search.name} (kp={safe_search.value})", file=sys.stderr)
@@ -455,6 +568,15 @@ def main():
         ),
     )
     parser.add_argument(
+        "--allow-private-urls",
+        action="store_true",
+        help=(
+            "Allow fetch_content to reach loopback/private/link-local/metadata "
+            "addresses. Off by default (SSRF guard). Enable only for trusted local "
+            "deployments. Also settable via DDG_ALLOW_PRIVATE_URLS=1."
+        ),
+    )
+    parser.add_argument(
         "--host",
         default=None,
         help="Bind address for sse / streamable-http transports (default: 127.0.0.1).",
@@ -475,9 +597,12 @@ def main():
     if transports == {"stdio"} and (args.host is not None or args.port is not None):
         parser.error("--host / --port are only valid with --transport sse or streamable-http")
 
-    # Reconfigure the module-level fetcher with the chosen backend.
-    fetcher = WebContentFetcher(backend=args.fetch_backend)
+    # Reconfigure the module-level fetcher with the chosen backend. Private-URL
+    # access is enabled if either the env var or the CLI flag is set.
+    allow_private = ALLOW_PRIVATE_URLS or args.allow_private_urls
+    fetcher = WebContentFetcher(backend=args.fetch_backend, allow_private_urls=allow_private)
     print(f"  Fetch backend: {fetcher.default_backend}", file=sys.stderr)
+    print(f"  Allow private URLs: {fetcher.allow_private_urls}", file=sys.stderr)
 
     if transports == {"stdio"}:
         mcp.run(transport="stdio")

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -239,7 +239,12 @@ async def _validate_public_url(url: str) -> None:
     if lowered == "localhost" or lowered.endswith(".localhost"):
         raise BlockedURLError(f"refusing to fetch loopback host '{host}'")
 
-    port = parsed.port or (443 if scheme == "https" else 80)
+    try:
+        port = parsed.port or (443 if scheme == "https" else 80)
+    except ValueError as e:
+        # urllib raises ValueError for an out-of-range port; treat as blocked
+        # rather than letting it surface as a generic unexpected error.
+        raise BlockedURLError(f"invalid port in URL '{url}': {e}") from e
     try:
         infos = await asyncio.to_thread(
             socket.getaddrinfo, host, port, 0, socket.SOCK_STREAM
@@ -252,8 +257,14 @@ async def _validate_public_url(url: str) -> None:
         # Unwrap IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) before classifying.
         if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
             ip = ip.ipv4_mapped
+        # `not is_global` is the primary catch-all (it also covers ranges the
+        # explicit flags miss, e.g. RFC 6598 CGNAT 100.64.0.0/10 used by Tailscale
+        # and some k8s/cloud fabrics). The explicit flags stay because a few ranges
+        # report is_global=True yet are non-routable (e.g. NAT64 64:ff9b::/96,
+        # caught by is_reserved).
         if (
-            ip.is_private
+            not ip.is_global
+            or ip.is_private
             or ip.is_loopback
             or ip.is_link_local
             or ip.is_reserved

--- a/src/duckduckgo_mcp_server/test_e2e.py
+++ b/src/duckduckgo_mcp_server/test_e2e.py
@@ -10,7 +10,19 @@ import pytest_asyncio
 
 from mcp.shared.memory import create_connected_server_and_client_session
 
+import duckduckgo_mcp_server.server as ddg_server
 from duckduckgo_mcp_server.server import mcp as mcp_app
+
+
+@pytest.fixture
+def allow_private_fetches():
+    """Let fetch_content reach the local test server (127.0.0.1) despite the SSRF guard."""
+    previous = ddg_server.fetcher.allow_private_urls
+    ddg_server.fetcher.allow_private_urls = True
+    try:
+        yield
+    finally:
+        ddg_server.fetcher.allow_private_urls = previous
 
 
 @pytest.fixture
@@ -78,7 +90,7 @@ async def test_server_lists_tools():
 
 
 @pytest.mark.asyncio
-async def test_fetch_content_tool_e2e(local_http_server):
+async def test_fetch_content_tool_e2e(local_http_server, allow_private_fetches):
     html = "<html><body><h1>Hello E2E</h1><p>Test content here.</p></body></html>"
     url = local_http_server(html)
 
@@ -114,7 +126,7 @@ async def test_search_tool_e2e(ddg_html_factory):
 
 
 @pytest.mark.asyncio
-async def test_fetch_content_tool_accepts_backend_param(local_http_server):
+async def test_fetch_content_tool_accepts_backend_param(local_http_server, allow_private_fetches):
     """The fetch_content tool should accept a per-call `backend` argument."""
     html = "<html><body><h1>Backend Param Test</h1></body></html>"
     url = local_http_server(html)

--- a/src/duckduckgo_mcp_server/test_server.py
+++ b/src/duckduckgo_mcp_server/test_server.py
@@ -571,6 +571,17 @@ class TestSSRFGuard(unittest.TestCase):
         # Either resolves to an IPv4 loopback or fails to resolve — both are blocked.
         self._assert_blocked("http://[::ffff:127.0.0.1]/")
 
+    def test_rejects_cgnat_shared_address_space(self):
+        # RFC 6598 100.64.0.0/10 is not is_private/is_reserved but is non-global;
+        # it's used by CGNAT and overlay networks like Tailscale.
+        self._assert_blocked("http://100.64.0.1/")
+        self._assert_blocked("http://100.127.255.254/")
+
+    def test_rejects_invalid_port(self):
+        # An out-of-range port makes urllib's .port raise ValueError; the guard
+        # should surface a clean BlockedURLError, not a generic failure.
+        self._assert_blocked("http://example.com:99999/")
+
     def test_rejects_non_http_scheme(self):
         self._assert_blocked("file:///etc/passwd")
         self._assert_blocked("ftp://example.com/x")

--- a/src/duckduckgo_mcp_server/test_server.py
+++ b/src/duckduckgo_mcp_server/test_server.py
@@ -19,6 +19,8 @@ from duckduckgo_mcp_server.server import (
     SearchResult,
     SUPPORTED_FETCH_BACKENDS,
     WebContentFetcher,
+    BlockedURLError,
+    _validate_public_url,
 )
 
 try:
@@ -290,7 +292,8 @@ class TestWebContentFetcher(unittest.TestCase):
         try:
             for backend in _FETCH_BACKENDS_FOR_TESTING:
                 with self.subTest(backend=backend):
-                    fetcher = WebContentFetcher(backend=backend)
+                    # Local server is on 127.0.0.1, so opt into private URLs.
+                    fetcher = WebContentFetcher(backend=backend, allow_private_urls=True)
                     text = asyncio.run(fetcher.fetch_and_parse(url, DummyCtx()))
                     self.assertIn("Sample Heading", text)
                     self.assertIn("Some meaningful paragraph.", text)
@@ -305,7 +308,7 @@ class TestWebContentFetcher(unittest.TestCase):
         try:
             for backend in _FETCH_BACKENDS_FOR_TESTING:
                 with self.subTest(backend=backend):
-                    fetcher = WebContentFetcher(backend=backend)
+                    fetcher = WebContentFetcher(backend=backend, allow_private_urls=True)
                     # Fetch first 50 chars
                     text = asyncio.run(
                         fetcher.fetch_and_parse(url, DummyCtx(), start_index=0, max_length=50)
@@ -348,7 +351,8 @@ class TestWebContentFetcherErrors(unittest.TestCase):
     def test_fetch_returns_error_on_timeout(self):
         for backend in _FETCH_BACKENDS_FOR_TESTING:
             with self.subTest(backend=backend):
-                fetcher = WebContentFetcher(backend=backend)
+                # These mock the HTTP client; skip the SSRF guard (no real DNS).
+                fetcher = WebContentFetcher(backend=backend, allow_private_urls=True)
                 # Use an exception whose type-name triggers the server's curl-path
                 # error handling without needing curl_cffi's exception hierarchy.
                 exc = httpx.TimeoutException("timed out") if backend == "httpx" else TimeoutError("timed out")
@@ -362,7 +366,8 @@ class TestWebContentFetcherErrors(unittest.TestCase):
     def test_fetch_returns_error_on_http_error(self):
         for backend in _FETCH_BACKENDS_FOR_TESTING:
             with self.subTest(backend=backend):
-                fetcher = WebContentFetcher(backend=backend)
+                # These mock the HTTP client; skip the SSRF guard (no real DNS).
+                fetcher = WebContentFetcher(backend=backend, allow_private_urls=True)
                 mock_resp = MagicMock()
                 mock_resp.status_code = 500
                 mock_resp.request = MagicMock()
@@ -380,7 +385,8 @@ class TestWebContentFetcherErrors(unittest.TestCase):
     def test_fetch_handles_malformed_html(self):
         for backend in _FETCH_BACKENDS_FOR_TESTING:
             with self.subTest(backend=backend):
-                fetcher = WebContentFetcher(backend=backend)
+                # These mock the HTTP client; skip the SSRF guard (no real DNS).
+                fetcher = WebContentFetcher(backend=backend, allow_private_urls=True)
                 mock_resp = MagicMock()
                 mock_resp.text = "<<<not valid>>>"
                 mock_resp.status_code = 200
@@ -534,6 +540,88 @@ class TestWebContentFetcherAutoFallback(unittest.TestCase):
 
         self.assertEqual(called["curl"], 0)
         self.assertTrue(result.startswith("Error"))
+
+
+class TestSSRFGuard(unittest.TestCase):
+    def _assert_blocked(self, url):
+        with self.assertRaises(BlockedURLError):
+            asyncio.run(_validate_public_url(url))
+
+    def test_rejects_loopback_ip(self):
+        self._assert_blocked("http://127.0.0.1/")
+        self._assert_blocked("http://127.0.0.1:8080/latest/meta-data/")
+
+    def test_rejects_localhost_hostname(self):
+        self._assert_blocked("http://localhost/")
+        self._assert_blocked("https://sub.localhost/")
+
+    def test_rejects_cloud_metadata_ip(self):
+        self._assert_blocked("http://169.254.169.254/latest/meta-data/")
+
+    def test_rejects_private_ips(self):
+        for host in ("10.0.0.1", "192.168.1.1", "172.16.5.4"):
+            with self.subTest(host=host):
+                self._assert_blocked(f"http://{host}/")
+
+    def test_rejects_unspecified_and_ipv6_loopback(self):
+        self._assert_blocked("http://0.0.0.0/")
+        self._assert_blocked("http://[::1]/")
+
+    def test_rejects_ipv4_mapped_ipv6_loopback(self):
+        # Either resolves to an IPv4 loopback or fails to resolve — both are blocked.
+        self._assert_blocked("http://[::ffff:127.0.0.1]/")
+
+    def test_rejects_non_http_scheme(self):
+        self._assert_blocked("file:///etc/passwd")
+        self._assert_blocked("ftp://example.com/x")
+        self._assert_blocked("gopher://127.0.0.1/")
+
+    def test_allows_public_ip_literals(self):
+        # Public IPs must pass. IP literals avoid a real DNS lookup.
+        for url in ("http://1.1.1.1/", "https://8.8.8.8/"):
+            with self.subTest(url=url):
+                asyncio.run(_validate_public_url(url))  # must not raise
+
+    def test_fetch_content_blocks_localhost_by_default(self):
+        fetcher = WebContentFetcher()
+        result = asyncio.run(fetcher.fetch_and_parse("http://127.0.0.1:9/", DummyCtx()))
+        self.assertIn("Refusing to fetch", result)
+        self.assertIn("DDG_ALLOW_PRIVATE_URLS", result)
+
+    def test_fetch_content_blocks_metadata_by_default(self):
+        fetcher = WebContentFetcher()
+        result = asyncio.run(
+            fetcher.fetch_and_parse("http://169.254.169.254/latest/meta-data/", DummyCtx())
+        )
+        self.assertIn("Refusing to fetch", result)
+
+    def test_fetch_content_allows_private_when_opted_in(self):
+        html = "<html><body><h1>Internal OK</h1></body></html>"
+        url, stop = _serve_html(html)
+        try:
+            fetcher = WebContentFetcher(allow_private_urls=True)
+            result = asyncio.run(fetcher.fetch_and_parse(url, DummyCtx()))
+            self.assertIn("Internal OK", result)
+        finally:
+            stop()
+
+    def test_redirect_to_private_is_blocked(self):
+        """A public entry URL that 302-redirects to a private host is blocked mid-hop."""
+        fetcher = WebContentFetcher()  # default-deny
+        redirect_resp = MagicMock()
+        redirect_resp.status_code = 302
+        redirect_resp.headers = {"location": "http://127.0.0.1/secret"}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=redirect_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = asyncio.run(fetcher.fetch_and_parse("http://1.1.1.1/", DummyCtx()))
+
+        self.assertIn("Refusing to fetch", result)
+        self.assertIn("127.0.0.1", result)
 
 
 def _setup_mock_mcp_for_http(mock_mcp):


### PR DESCRIPTION
## Problem

`fetch_content` forwarded a caller-supplied URL straight into the HTTP client with `follow_redirects=True` and no host validation, returning the response body. That makes it a non-blind **SSRF** primitive: it could read loopback services, RFC1918 hosts, and cloud metadata (`169.254.169.254`) and return their contents (#48).

## Fix

- `_validate_public_url()`: require `http`/`https` and reject hosts that resolve to loopback / private / link-local / reserved / multicast / unspecified addresses (unwrapping IPv4-mapped IPv6). Raises `BlockedURLError`.
- Follow redirects **manually** in both the httpx and curl backends (max 5 hops), re-validating **every hop** so a public URL can't bounce a request into the internal network.
- **Default-deny** with an opt-out for trusted local setups: `DDG_ALLOW_PRIVATE_URLS=1` or `--allow-private-urls`.
- Clean, actionable error (no stack trace) when a target is blocked.
- Adds `SECURITY.md` (reporting policy + SSRF/untrusted-content notes) and README docs.

> Note: validation resolves the host and the client resolves it again to connect, leaving a small DNS-rebinding (TOCTOU) window. Pinning the connection to the validated IP is out of scope; default-deny + per-hop validation blocks the practical vectors.

## Verification

- New tests: URL-validator truth table (localhost, `169.254.169.254`, RFC1918, IPv6 loopback, `file://`), tool-level blocking, opt-in allow, and redirect-to-private rejection. Full suite passes.
- Manually confirmed: localhost / metadata / `file://` / private all refused by default; public URLs and the opt-in flag work.

Closes #48.
