### PR TITLE
feat(http): configurable DNS-rebinding protection to fix 421 behind proxies (#45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Environment variables read at startup (not per-request):
 - `DDG_REGION`: Region code like `us-en`, `cn-zh`, `jp-ja`, `wt-wt`
 - `DDG_ALLOW_PRIVATE_URLS`: `1`/`true` to let `fetch_content` reach loopback/private/link-local/metadata addresses (default off — SSRF guard). Also settable via `--allow-private-urls`.
 - `DDG_SEARCH_BACKEND`: `auto` (default) | `httpx` | `curl` — HTTP backend for the search tool. `auto` falls back to curl_cffi Chrome TLS impersonation when DuckDuckGo returns a fingerprint block (HTTP 202/403); `curl`/fallback need the `[browser]` extra. Also settable via `--search-backend`.
+- `DDG_ALLOWED_HOSTS` / `DDG_ALLOWED_ORIGINS`: comma-separated Host/Origin allow-lists for the HTTP transports (DNS-rebinding protection). Needed behind a reverse proxy / in Docker to avoid `421 Misdirected Request`. Also `--allowed-hosts` / `--allowed-origins`, or `--disable-dns-rebinding-protection` (`DDG_DISABLE_DNS_REBINDING_PROTECTION`).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ When running with `sse` or `streamable-http`, override the default bind address 
 uvx duckduckgo-mcp-server --transport streamable-http --host 0.0.0.0 --port 7070
 ```
 
+#### Running behind a reverse proxy or in Docker
+
+FastMCP enables DNS-rebinding protection for the HTTP transports and, by default, only accepts `Host`/`Origin` headers for `localhost`. Behind a reverse proxy or in a container the client's `Host` header won't match, so requests fail with **`421 Misdirected Request`**.
+
+Fix it by allow-listing the host(s) and origin(s) clients actually use (preferred over disabling protection). Values support `host`, `host:port`, and wildcard-port `host:*`:
+
+```bash
+uvx duckduckgo-mcp-server --transport streamable-http --host 0.0.0.0 --port 7070 \
+  --allowed-hosts ddg-mcp.example.com "ddg-mcp.example.com:*" \
+  --allowed-origins "https://ddg-mcp.example.com"
+```
+
+Equivalent environment variables (comma-separated) are also available: `DDG_ALLOWED_HOSTS`, `DDG_ALLOWED_ORIGINS`.
+
+As a last resort you can turn the check off entirely with `--disable-dns-rebinding-protection` (or `DDG_DISABLE_DNS_REBINDING_PROTECTION=1`). Prefer an allow-list — disabling protection removes a defense against DNS-rebinding attacks. When nothing is configured, the secure localhost-only default is preserved.
+
 ### Backends (bypassing bot detection)
 
 Some sites — and, as of recently, DuckDuckGo's own search endpoint (`html.duckduckgo.com`) — block the default `httpx` client because of its distinctive TLS fingerprint, regardless of User-Agent. Cloudflare Bot Management and similar filters key on the JA3/TLS handshake, not on headers, so `html.duckduckgo.com` may answer `httpx` with an empty **HTTP 202** page (silently yielding "no results"). An opt-in backend, `curl` (implemented via `curl_cffi`), impersonates a real Chrome browser's TLS handshake and passes through those checks.

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -630,11 +630,39 @@ def _env_flag(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
 
 
+def _split_env_list(name: str) -> list:
+    """Parse a comma-separated env var into a list of trimmed, non-empty items."""
+    return [item.strip() for item in os.getenv(name, "").split(",") if item.strip()]
+
+
+def _build_transport_security(allowed_hosts, allowed_origins, disable):
+    """Build TransportSecuritySettings for HTTP transports, or None to keep defaults.
+
+    Returns None when nothing is configured (so FastMCP's secure localhost default is
+    preserved). When an allow-list is given, DNS rebinding protection stays on but the
+    supplied Host/Origin values are permitted — the fix for 421 Misdirected Request
+    behind a reverse proxy / in Docker (issue #45). `disable` turns the protection off
+    entirely (less safe; prefer an allow-list).
+    """
+    if not (allowed_hosts or allowed_origins or disable):
+        return None
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=not disable,
+        allowed_hosts=list(allowed_hosts or []),
+        allowed_origins=list(allowed_origins or []),
+    )
+
+
 # Read configuration from environment variables
 SAFE_SEARCH_MODE = os.getenv("DDG_SAFE_SEARCH", "MODERATE").upper()
 REGION_CODE = os.getenv("DDG_REGION", "")
 ALLOW_PRIVATE_URLS = _env_flag("DDG_ALLOW_PRIVATE_URLS")
 SEARCH_BACKEND = os.getenv("DDG_SEARCH_BACKEND", "auto").lower()
+ALLOWED_HOSTS = _split_env_list("DDG_ALLOWED_HOSTS")
+ALLOWED_ORIGINS = _split_env_list("DDG_ALLOWED_ORIGINS")
+DISABLE_DNS_REBINDING = _env_flag("DDG_DISABLE_DNS_REBINDING_PROTECTION")
 
 # Validate and set SafeSearch mode
 try:
@@ -759,6 +787,39 @@ def main():
         default=None,
         help="Bind port for sse / streamable-http transports (default: 8000).",
     )
+    parser.add_argument(
+        "--allowed-hosts",
+        nargs="+",
+        default=None,
+        metavar="HOST",
+        help=(
+            "Allowed Host header values for sse / streamable-http (DNS rebinding "
+            "protection). Accepts 'host', 'host:port', or 'host:*'. Set this (and/or "
+            "--allowed-origins) when running behind a reverse proxy or in Docker to "
+            "avoid 421 Misdirected Request. Also settable via DDG_ALLOWED_HOSTS "
+            "(comma-separated). Only affects HTTP transports."
+        ),
+    )
+    parser.add_argument(
+        "--allowed-origins",
+        nargs="+",
+        default=None,
+        metavar="ORIGIN",
+        help=(
+            "Allowed Origin header values for sse / streamable-http (e.g. "
+            "'http://example.com:*'). Also settable via DDG_ALLOWED_ORIGINS "
+            "(comma-separated). Only affects HTTP transports."
+        ),
+    )
+    parser.add_argument(
+        "--disable-dns-rebinding-protection",
+        action="store_true",
+        help=(
+            "Disable Host/Origin validation for sse / streamable-http entirely. Less "
+            "safe than an allow-list; prefer --allowed-hosts / --allowed-origins. Also "
+            "settable via DDG_DISABLE_DNS_REBINDING_PROTECTION=1."
+        ),
+    )
     args = parser.parse_args()
 
     transports = set(args.transport)
@@ -791,6 +852,22 @@ def main():
         port = args.port or 8000
         mcp.settings.host = host
         mcp.settings.port = port
+
+        # Configure DNS-rebinding protection. By default FastMCP only allows
+        # localhost Host/Origin headers, which yields 421 Misdirected Request behind
+        # a reverse proxy / in Docker (issue #45). Applying an allow-list (or an
+        # explicit disable) here overrides that before the apps are built.
+        allowed_hosts = args.allowed_hosts if args.allowed_hosts is not None else ALLOWED_HOSTS
+        allowed_origins = args.allowed_origins if args.allowed_origins is not None else ALLOWED_ORIGINS
+        disable_dns = args.disable_dns_rebinding_protection or DISABLE_DNS_REBINDING
+        transport_security = _build_transport_security(allowed_hosts, allowed_origins, disable_dns)
+        if transport_security is not None:
+            mcp.settings.transport_security = transport_security
+            print(
+                f"  Transport security: dns_rebinding_protection={not disable_dns}, "
+                f"allowed_hosts={allowed_hosts or '[]'}, allowed_origins={allowed_origins or '[]'}",
+                file=sys.stderr,
+            )
 
         # SSE and Streamable HTTP app setup
         sse_app = mcp.sse_app()

--- a/src/duckduckgo_mcp_server/test_server.py
+++ b/src/duckduckgo_mcp_server/test_server.py
@@ -11,6 +11,7 @@ import httpx
 from starlette.routing import Route as StarletteRoute
 
 import duckduckgo_mcp_server.server
+from duckduckgo_mcp_server.server import _build_transport_security
 
 from duckduckgo_mcp_server.server import (
     RateLimiter,
@@ -948,6 +949,50 @@ class TestMainCliArgs(unittest.TestCase):
             call_kwargs = mock_uvicorn_run.call_args.kwargs
             self.assertEqual(call_kwargs["host"], "127.0.0.1")
             self.assertEqual(call_kwargs["port"], 8000)
+
+
+class TestTransportSecurity(unittest.TestCase):
+    def test_build_returns_none_when_unset(self):
+        # Nothing configured → keep FastMCP's secure default (None).
+        self.assertIsNone(_build_transport_security([], [], False))
+
+    def test_build_allowlist_keeps_protection_on(self):
+        ts = _build_transport_security(["ex.com:*"], ["http://ex.com:*"], False)
+        self.assertTrue(ts.enable_dns_rebinding_protection)
+        self.assertEqual(ts.allowed_hosts, ["ex.com:*"])
+        self.assertEqual(ts.allowed_origins, ["http://ex.com:*"])
+
+    def test_build_disable_turns_protection_off(self):
+        ts = _build_transport_security([], [], True)
+        self.assertIsNotNone(ts)
+        self.assertFalse(ts.enable_dns_rebinding_protection)
+
+    def test_main_applies_allowed_hosts(self):
+        argv = [
+            "duckduckgo-mcp-server", "--transport", "streamable-http",
+            "--allowed-hosts", "ddg.example.com", "ddg.example.com:*",
+        ]
+        with patch.object(sys, "argv", argv), \
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
+             patch("uvicorn.run"):
+            _setup_mock_mcp_for_http(mock_mcp)
+            duckduckgo_mcp_server.server.main()
+            ts = mock_mcp.settings.transport_security
+            self.assertTrue(ts.enable_dns_rebinding_protection)
+            self.assertEqual(ts.allowed_hosts, ["ddg.example.com", "ddg.example.com:*"])
+
+    def test_main_disable_dns_rebinding_protection(self):
+        argv = [
+            "duckduckgo-mcp-server", "--transport", "sse",
+            "--disable-dns-rebinding-protection",
+        ]
+        with patch.object(sys, "argv", argv), \
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp, \
+             patch("uvicorn.run"):
+            _setup_mock_mcp_for_http(mock_mcp)
+            duckduckgo_mcp_server.server.main()
+            ts = mock_mcp.settings.transport_security
+            self.assertFalse(ts.enable_dns_rebinding_protection)
 
 
 class TestConfiguration(unittest.TestCase):


### PR DESCRIPTION
## Problem

FastMCP auto-enables DNS-rebinding protection for the HTTP transports with a **localhost-only** Host/Origin allow-list. Behind a reverse proxy or in Docker the client's `Host` header doesn't match, so every `sse`/`streamable-http` request fails with **`421 Misdirected Request`** (#45) — with no way to configure the allow-list.

## Fix

- Add `--allowed-hosts` / `--allowed-origins` (and `DDG_ALLOWED_HOSTS` / `DDG_ALLOWED_ORIGINS`, comma-separated) to permit proxy/container hosts. Values support `host`, `host:port`, and `host:*`.
- Add `--disable-dns-rebinding-protection` (`DDG_DISABLE_DNS_REBINDING_PROTECTION`) as an escape hatch; docs steer operators toward the allow-list.
- Applied via `mcp.settings.transport_security` **before** the HTTP apps are built, so it overrides the localhost default. When nothing is configured, the secure default is preserved unchanged.
- README "Running behind a reverse proxy or in Docker" section.

## Verification

- Tests for the settings builder and CLI wiring; full suite passes.
- Verified live: a mismatched `Host` returns **421** by default, and **406** (not 421 — Host check passed) once the host is allow-listed or protection is disabled.

Closes #45.
