### PR TITLE
feat(ssl): custom CA bundle and TLS verification config (#54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,11 +58,12 @@ Environment variables read at startup (not per-request):
 - `DDG_ALLOW_PRIVATE_URLS`: `1`/`true` to let `fetch_content` reach loopback/private/link-local/metadata addresses (default off — SSRF guard). Also settable via `--allow-private-urls`.
 - `DDG_SEARCH_BACKEND`: `auto` (default) | `httpx` | `curl` — HTTP backend for the search tool. `auto` falls back to curl_cffi Chrome TLS impersonation when DuckDuckGo returns a fingerprint block (HTTP 202/403); `curl`/fallback need the `[browser]` extra. Also settable via `--search-backend`.
 - `DDG_ALLOWED_HOSTS` / `DDG_ALLOWED_ORIGINS`: comma-separated Host/Origin allow-lists for the HTTP transports (DNS-rebinding protection). Needed behind a reverse proxy / in Docker to avoid `421 Misdirected Request`. Also `--allowed-hosts` / `--allowed-origins`, or `--disable-dns-rebinding-protection` (`DDG_DISABLE_DNS_REBINDING_PROTECTION`).
+- `DDG_CA_CERTS`: path to a PEM CA bundle for verifying TLS on outbound requests (needed behind TLS-intercepting proxies — httpx no longer reads `SSL_CERT_FILE`). `DDG_SSL_VERIFY=0` disables verification entirely (discouraged). Also `--ca-certs` / `--no-ssl-verify`. Applies to all four client sites (httpx + curl_cffi, search + fetch).
 
 ## Testing
 
-- **Unit tests** (`test_server.py`): 21 tests using `unittest` style with `unittest.mock.patch` to mock httpx. Covers rate limiter, search parsing, content fetching errors, and configuration.
-- **E2E tests** (`test_e2e.py`): 4 tests using `pytest-asyncio` with MCP SDK's `create_connected_server_and_client_session` from `mcp.shared.memory` for in-memory MCP client/server testing.
+- **Unit tests** (`test_server.py`): 78 tests using `unittest` style with `unittest.mock.patch` to mock httpx. Covers rate limiter, search parsing, content fetching errors, and configuration.
+- **E2E tests** (`test_e2e.py`): 6 tests using `pytest-asyncio` with MCP SDK's `create_connected_server_and_client_session` from `mcp.shared.memory` for in-memory MCP client/server testing.
 - **CI**: GitHub Actions (`.github/workflows/test.yml`) runs a `test` job (pytest on Python 3.10–3.14) and a `quality` job (`ruff check` — blocking — plus a non-blocking `pip-audit` dependency scan), all using `astral-sh/setup-uv`.
 
 ## Key Dependencies

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Add the following configuration:
   - `jp-ja`: Japan (Japanese)
   - `wt-wt`: No specific region
   - Leave empty for DuckDuckGo's default behavior
+- `DDG_CA_CERTS`: Path to a PEM CA bundle used to verify TLS certificates on outbound requests (optional). Needed behind TLS-intercepting proxies — see [Running behind a TLS-intercepting proxy](#running-behind-a-tls-intercepting-proxy).
 
 3. Restart Claude Desktop
 
@@ -122,6 +123,18 @@ uvx duckduckgo-mcp-server --transport streamable-http --host 0.0.0.0 --port 7070
 Equivalent environment variables (comma-separated) are also available: `DDG_ALLOWED_HOSTS`, `DDG_ALLOWED_ORIGINS`.
 
 As a last resort you can turn the check off entirely with `--disable-dns-rebinding-protection` (or `DDG_DISABLE_DNS_REBINDING_PROTECTION=1`). Prefer an allow-list — disabling protection removes a defense against DNS-rebinding attacks. When nothing is configured, the secure localhost-only default is preserved.
+
+#### Running behind a TLS-intercepting proxy
+
+Corporate proxies that re-sign HTTPS traffic with their own CA (via `HTTPS_PROXY`) cause outbound requests to fail with certificate verification errors, because the HTTP clients don't trust the proxy's self-signed CA (and httpx no longer reads the `SSL_CERT_FILE` environment variable). Point the server at your proxy's CA bundle:
+
+```bash
+uvx duckduckgo-mcp-server --ca-certs /path/to/proxy-ca.pem
+```
+
+Or set `DDG_CA_CERTS=/path/to/proxy-ca.pem`. The bundle is used by both the `search` and `fetch_content` tools, on the httpx and curl backends alike.
+
+As a last resort, `--no-ssl-verify` (or `DDG_SSL_VERIFY=0`) disables certificate verification entirely. This exposes traffic to interception by anyone on the network path — prefer `--ca-certs`.
 
 ### Backends (bypassing bot detection)
 

--- a/src/duckduckgo_mcp_server/server.py
+++ b/src/duckduckgo_mcp_server/server.py
@@ -106,6 +106,7 @@ class DuckDuckGoSearcher:
         safe_search: SafeSearchMode = SafeSearchMode.MODERATE,
         default_region: str = "",
         backend: str = "auto",
+        ssl_verify=True,
     ):
         """
         Initialize DuckDuckGo searcher
@@ -118,6 +119,9 @@ class DuckDuckGoSearcher:
                 to curl_cffi Chrome TLS impersonation when DuckDuckGo returns a
                 fingerprint-based block (HTTP 202/403). "curl" and the auto fallback
                 require the optional [browser] extra.
+            ssl_verify: TLS verification passed to the HTTP clients: True (default
+                trust store), a path to a CA bundle (e.g. a TLS-intercepting proxy's
+                CA), or False to disable verification.
         """
         if backend not in SUPPORTED_FETCH_BACKENDS:
             raise ValueError(
@@ -127,6 +131,7 @@ class DuckDuckGoSearcher:
         self.safe_search = safe_search
         self.default_region = default_region
         self.backend = backend
+        self.ssl_verify = ssl_verify
 
     def format_results_for_llm(self, results: List[SearchResult]) -> str:
         """Format results in a natural language style that's easier for LLMs to process"""
@@ -298,7 +303,7 @@ class DuckDuckGoSearcher:
         Note: a fingerprint-blocked response is HTTP 202 (a 2xx), so
         ``raise_for_status()`` does not fire — the caller inspects the status.
         """
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=self.ssl_verify) as client:
             response = await client.post(
                 self.BASE_URL, data=data, headers=self.HEADERS, timeout=30.0
             )
@@ -316,7 +321,7 @@ class DuckDuckGoSearcher:
             ) from e
         # Let curl_cffi supply the impersonated browser headers for a consistent
         # Chrome fingerprint; we only send the search form fields.
-        async with AsyncSession(impersonate="chrome131") as client:
+        async with AsyncSession(impersonate="chrome131", verify=self.ssl_verify) as client:
             response = await client.post(self.BASE_URL, data=data, timeout=30.0)
             response.raise_for_status()
             return response.text
@@ -418,7 +423,7 @@ async def _validate_public_url(url: str) -> None:
 
 
 class WebContentFetcher:
-    def __init__(self, backend: str = "httpx", allow_private_urls: bool = False):
+    def __init__(self, backend: str = "httpx", allow_private_urls: bool = False, ssl_verify=True):
         """
         Initialize the web content fetcher.
 
@@ -435,6 +440,9 @@ class WebContentFetcher:
                 resolve to loopback/private/link-local/metadata addresses (SSRF guard).
                 Set True only for trusted local deployments that intentionally fetch
                 internal hosts.
+            ssl_verify: TLS verification passed to the HTTP clients: True (default
+                trust store), a path to a CA bundle (e.g. a TLS-intercepting proxy's
+                CA), or False to disable verification.
         """
         if backend not in SUPPORTED_FETCH_BACKENDS:
             raise ValueError(
@@ -442,6 +450,7 @@ class WebContentFetcher:
             )
         self.default_backend = backend
         self.allow_private_urls = allow_private_urls
+        self.ssl_verify = ssl_verify
         self.rate_limiter = RateLimiter(requests_per_minute=20)
 
     async def _guard_url(self, url: str) -> None:
@@ -455,7 +464,7 @@ class WebContentFetcher:
         Redirects are followed manually (not via follow_redirects=True) so the SSRF
         guard runs on each hop. Raises httpx.HTTPStatusError on non-2xx.
         """
-        async with httpx.AsyncClient(follow_redirects=False) as client:
+        async with httpx.AsyncClient(follow_redirects=False, verify=self.ssl_verify) as client:
             current = url
             for _ in range(_MAX_REDIRECTS + 1):
                 await self._guard_url(current)
@@ -486,7 +495,7 @@ class WebContentFetcher:
                 "The 'curl' fetch backend requires curl_cffi, which is not installed. "
                 "Install the optional extra: pip install 'duckduckgo-mcp-server[browser]'"
             ) from e
-        async with AsyncSession(impersonate="chrome131") as client:
+        async with AsyncSession(impersonate="chrome131", verify=self.ssl_verify) as client:
             current = url
             for _ in range(_MAX_REDIRECTS + 1):
                 await self._guard_url(current)
@@ -634,6 +643,21 @@ def _split_env_list(name: str) -> list:
     return [item.strip() for item in os.getenv(name, "").split(",") if item.strip()]
 
 
+def _resolve_ssl_verify(ca_certs: str, verify_enabled: bool = True):
+    """Return the value to pass as ``verify=`` to the outbound HTTP clients.
+
+    False disables certificate verification entirely (insecure escape hatch); a CA
+    bundle path makes the clients trust that bundle — needed behind TLS-intercepting
+    proxies with a self-signed CA, which httpx otherwise rejects since it no longer
+    reads SSL_CERT_FILE (issue #54); True keeps each client's default trust store.
+    """
+    if not verify_enabled:
+        return False
+    if ca_certs:
+        return ca_certs
+    return True
+
+
 def _build_transport_security(allowed_hosts, allowed_origins, disable):
     """Build TransportSecuritySettings for HTTP transports, or None to keep defaults.
 
@@ -662,6 +686,12 @@ SEARCH_BACKEND = os.getenv("DDG_SEARCH_BACKEND", "auto").lower()
 ALLOWED_HOSTS = _split_env_list("DDG_ALLOWED_HOSTS")
 ALLOWED_ORIGINS = _split_env_list("DDG_ALLOWED_ORIGINS")
 DISABLE_DNS_REBINDING = _env_flag("DDG_DISABLE_DNS_REBINDING_PROTECTION")
+CA_CERTS = os.getenv("DDG_CA_CERTS", "").strip()
+SSL_VERIFY_ENABLED = os.getenv("DDG_SSL_VERIFY", "1").strip().lower() not in ("0", "false", "no", "off")
+SSL_VERIFY = _resolve_ssl_verify(CA_CERTS, SSL_VERIFY_ENABLED)
+
+if CA_CERTS and not os.path.isfile(CA_CERTS):
+    print(f"Warning: DDG_CA_CERTS path '{CA_CERTS}' does not exist; TLS requests will fail", file=sys.stderr)
 
 # Validate and set SafeSearch mode
 try:
@@ -675,13 +705,17 @@ if SEARCH_BACKEND not in SUPPORTED_FETCH_BACKENDS:
     print(f"Warning: Invalid DDG_SEARCH_BACKEND value '{SEARCH_BACKEND}', using auto", file=sys.stderr)
     SEARCH_BACKEND = "auto"
 
-searcher = DuckDuckGoSearcher(safe_search=safe_search, default_region=REGION_CODE, backend=SEARCH_BACKEND)
-fetcher = WebContentFetcher(allow_private_urls=ALLOW_PRIVATE_URLS)
+searcher = DuckDuckGoSearcher(
+    safe_search=safe_search, default_region=REGION_CODE, backend=SEARCH_BACKEND, ssl_verify=SSL_VERIFY
+)
+fetcher = WebContentFetcher(allow_private_urls=ALLOW_PRIVATE_URLS, ssl_verify=SSL_VERIFY)
 
 print("DuckDuckGo MCP Server initialized:", file=sys.stderr)
 print(f"  SafeSearch: {safe_search.name} (kp={safe_search.value})", file=sys.stderr)
 print(f"  Default Region: {REGION_CODE or 'none'}", file=sys.stderr)
 print(f"  Search backend: {searcher.backend}", file=sys.stderr)
+if SSL_VERIFY is not True:
+    print(f"  SSL verify: {SSL_VERIFY}", file=sys.stderr)
 
 
 @mcp.tool()
@@ -776,6 +810,26 @@ def main():
         ),
     )
     parser.add_argument(
+        "--ca-certs",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to a PEM CA bundle used to verify TLS certificates on outbound "
+            "requests (search and fetch_content). Needed behind TLS-intercepting "
+            "proxies that re-sign traffic with their own CA. Also settable via "
+            "DDG_CA_CERTS."
+        ),
+    )
+    parser.add_argument(
+        "--no-ssl-verify",
+        action="store_true",
+        help=(
+            "Disable TLS certificate verification on outbound requests entirely. "
+            "Insecure; prefer --ca-certs with your proxy's CA bundle. Also settable "
+            "via DDG_SSL_VERIFY=0."
+        ),
+    )
+    parser.add_argument(
         "--host",
         default=None,
         help="Bind address for sse / streamable-http transports (default: 127.0.0.1).",
@@ -829,18 +883,32 @@ def main():
     if transports == {"stdio"} and (args.host is not None or args.port is not None):
         parser.error("--host / --port are only valid with --transport sse or streamable-http")
 
+    if args.ca_certs is not None and not os.path.isfile(args.ca_certs):
+        parser.error(f"--ca-certs path '{args.ca_certs}' does not exist")
+
+    # CLI flags override the env-derived SSL settings.
+    ca_certs = args.ca_certs if args.ca_certs is not None else CA_CERTS
+    ssl_verify = _resolve_ssl_verify(ca_certs, SSL_VERIFY_ENABLED and not args.no_ssl_verify)
+
     # Reconfigure the module-level fetcher with the chosen backend. Private-URL
     # access is enabled if either the env var or the CLI flag is set.
     allow_private = ALLOW_PRIVATE_URLS or args.allow_private_urls
-    fetcher = WebContentFetcher(backend=args.fetch_backend, allow_private_urls=allow_private)
+    fetcher = WebContentFetcher(
+        backend=args.fetch_backend, allow_private_urls=allow_private, ssl_verify=ssl_verify
+    )
     print(f"  Fetch backend: {fetcher.default_backend}", file=sys.stderr)
     print(f"  Allow private URLs: {fetcher.allow_private_urls}", file=sys.stderr)
+    if ssl_verify is not True:
+        print(f"  SSL verify: {ssl_verify}", file=sys.stderr)
 
-    # Reconfigure the module-level searcher if a backend was given on the CLI
-    # (otherwise it keeps the env-derived DDG_SEARCH_BACKEND default).
-    if args.search_backend is not None:
+    # Reconfigure the module-level searcher if a backend or SSL setting was given on
+    # the CLI (otherwise it keeps the env-derived defaults).
+    if args.search_backend is not None or ssl_verify != searcher.ssl_verify:
         searcher = DuckDuckGoSearcher(
-            safe_search=safe_search, default_region=REGION_CODE, backend=args.search_backend
+            safe_search=safe_search,
+            default_region=REGION_CODE,
+            backend=args.search_backend or searcher.backend,
+            ssl_verify=ssl_verify,
         )
         print(f"  Search backend: {searcher.backend}", file=sys.stderr)
 

--- a/src/duckduckgo_mcp_server/test_server.py
+++ b/src/duckduckgo_mcp_server/test_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import tempfile
 import threading
 from datetime import datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -22,6 +23,7 @@ from duckduckgo_mcp_server.server import (
     BlockedURLError,
     _validate_public_url,
     _is_search_block,
+    _resolve_ssl_verify,
 )
 
 try:
@@ -992,6 +994,77 @@ class TestTransportSecurity(unittest.TestCase):
             duckduckgo_mcp_server.server.main()
             ts = mock_mcp.settings.transport_security
             self.assertFalse(ts.enable_dns_rebinding_protection)
+
+
+class TestSSLVerifyConfig(unittest.TestCase):
+    def test_resolve_ssl_verify(self):
+        # Default: verification on with the client's own trust store.
+        self.assertIs(_resolve_ssl_verify(""), True)
+        # A CA bundle path is passed through as the verify value.
+        self.assertEqual(_resolve_ssl_verify("/etc/proxy-ca.pem"), "/etc/proxy-ca.pem")
+        # Disabling verification wins over a CA bundle.
+        self.assertIs(_resolve_ssl_verify("/etc/proxy-ca.pem", verify_enabled=False), False)
+        self.assertIs(_resolve_ssl_verify("", verify_enabled=False), False)
+
+    def test_defaults_to_verified(self):
+        self.assertIs(DuckDuckGoSearcher().ssl_verify, True)
+        self.assertIs(WebContentFetcher().ssl_verify, True)
+
+    def test_searcher_passes_verify_to_httpx_client(self):
+        searcher = DuckDuckGoSearcher(backend="httpx", ssl_verify="/etc/proxy-ca.pem")
+        mock_resp = _mock_post_response("<html><body></body></html>")
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client) as mock_cls:
+            asyncio.run(searcher.search("test", DummyCtx()))
+
+        self.assertEqual(mock_cls.call_args.kwargs.get("verify"), "/etc/proxy-ca.pem")
+
+    def test_fetcher_passes_verify_to_httpx_client(self):
+        fetcher = WebContentFetcher(allow_private_urls=True, ssl_verify=False)
+        mock_resp = MagicMock()
+        mock_resp.text = "<html><body><p>ok</p></body></html>"
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.raise_for_status = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client) as mock_cls:
+            asyncio.run(fetcher.fetch_and_parse("https://example.com", DummyCtx()))
+
+        self.assertIs(mock_cls.call_args.kwargs.get("verify"), False)
+
+    def test_main_parses_ca_certs_flag(self):
+        with tempfile.NamedTemporaryFile(suffix=".pem") as ca_file:
+            argv = ["duckduckgo-mcp-server", "--ca-certs", ca_file.name]
+            with patch.object(sys, "argv", argv), \
+                 patch("duckduckgo_mcp_server.server.mcp") as mock_mcp:
+                duckduckgo_mcp_server.server.main()
+                mock_mcp.run.assert_called_once()
+            self.assertEqual(duckduckgo_mcp_server.server.fetcher.ssl_verify, ca_file.name)
+            self.assertEqual(duckduckgo_mcp_server.server.searcher.ssl_verify, ca_file.name)
+
+    def test_main_parses_no_ssl_verify_flag(self):
+        argv = ["duckduckgo-mcp-server", "--no-ssl-verify"]
+        with patch.object(sys, "argv", argv), \
+             patch("duckduckgo_mcp_server.server.mcp") as mock_mcp:
+            duckduckgo_mcp_server.server.main()
+            mock_mcp.run.assert_called_once()
+        self.assertIs(duckduckgo_mcp_server.server.fetcher.ssl_verify, False)
+        self.assertIs(duckduckgo_mcp_server.server.searcher.ssl_verify, False)
+
+    def test_main_rejects_missing_ca_certs_path(self):
+        argv = ["duckduckgo-mcp-server", "--ca-certs", "/nonexistent/ca-bundle.pem"]
+        with patch.object(sys, "argv", argv), \
+             patch("duckduckgo_mcp_server.server.mcp"):
+            with self.assertRaises(SystemExit):
+                duckduckgo_mcp_server.server.main()
 
 
 class TestConfiguration(unittest.TestCase):


### PR DESCRIPTION
## Problem

Behind a TLS-intercepting proxy (`HTTPS_PROXY` with a self-signed CA), every outbound request fails certificate verification: httpx no longer reads `SSL_CERT_FILE`/`SSL_CERT_DIR`, and there was no way to hand the clients a custom CA (#54).

## Fix

- `--ca-certs PATH` / `DDG_CA_CERTS`: PEM CA bundle passed as `verify=` to **all four outbound client sites** — httpx and curl_cffi, for both `search` and `fetch_content`. (curl_cffi's `verify` is typed `bool` but accepts a path, mapping to `CAINFO`; verified against a live endpoint.)
- `--no-ssl-verify` / `DDG_SSL_VERIFY=0`: disables verification entirely. Documented as a last resort; `--ca-certs` is steered to first.
- Startup warning when `DDG_CA_CERTS` points at a missing file; `parser.error` on a missing `--ca-certs` path.
- README section "Running behind a TLS-intercepting proxy" + config docs.

## Verification

- New tests: resolution-helper truth table, `verify=` wiring into `httpx.AsyncClient` for search and fetch, CLI flag wiring for both flags, missing-path rejection.
- Full suite passes (84 tests, incl. curl backend subtests with the `[browser]` extra installed); `ruff check` clean.
- Live check: `AsyncSession(impersonate='chrome131', verify='<ca path>')` → HTTP 200.

Closes #54.