### PR TITLE
Updated Dockerfile to allow command-line parameters to be passed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ COPY . /app
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir .
 
-# MCP uses stdio, no port to expose.
-CMD ["python", "-m", "duckduckgo_mcp_server.server"]
+# Updated to allow command-line switches to be passed via docker commands
+ENTRYPOINT ["python", "-m", "duckduckgo_mcp_server.server"]
+CMD []


### PR DESCRIPTION
This update changes the Dockerfile to use ENTRYPOINT and a blank default CMD. This allows passing of parameters to the python server via docker i.e. ```docker run -p 8000:8000 duckduckgo-mcp-server --transport streamable-http --port 8000 --host 0.0.0.0```